### PR TITLE
wikihub-activity-sidebar-r1: add activity feed and gate curator sidebar

### DIFF
--- a/app/routes/wiki.py
+++ b/app/routes/wiki.py
@@ -22,6 +22,8 @@ from app.models import (
     ProposalComment,
     ProposalPagePatch,
     ProposalRevision,
+    Fork,
+    Star,
     User,
     UsernameRedirect,
     Wiki,
@@ -361,6 +363,7 @@ def _page_url(username, slug, page_path):
 _SIDEBAR_NON_CONTENT_ROOTS = {
     "-",
     "commit",
+    "activity",
     "graph",
     "graph.json",
     "history",
@@ -554,6 +557,116 @@ def _build_sidebar_tree(username, slug, wiki, public=False, current_path=None, a
         return sorted(items, key=lambda item: (item["kind"] != "folder", item["name"].lower(), item["path"]))
 
     return normalize(root["children"])
+
+
+def _activity_time(value):
+    if value is None:
+        return utcnow()
+    return value
+
+
+def _viewer_can_see_proposal(proposal, owner, wiki):
+    revision, patch = _latest_proposal_patch(proposal)
+    if not patch:
+        return False
+    page = Page.query.filter_by(wiki_id=wiki.id, path=patch.page_path).first()
+    return _proposal_participant_can_view(proposal, page, owner, wiki, patch)
+
+
+def _wiki_activity_items(owner, wiki, acl_rules, limit=60):
+    """Build a mixed recent-activity feed from existing durable rows.
+
+    This intentionally avoids a new event table. Page rows, proposals, stars,
+    and forks already capture the product events users care about, and each item
+    is filtered through the same ACL checks used by reader/history routes.
+    """
+    items = []
+    visible_pages = []
+    for page in Page.query.filter_by(wiki_id=wiki.id).order_by(Page.updated_at.desc()).limit(120).all():
+        if _viewer_can_read_page(wiki, page, acl_rules=acl_rules, owner=owner):
+            visible_pages.append(page)
+            verb = "created" if abs((_activity_time(page.updated_at) - _activity_time(page.created_at)).total_seconds()) < 2 else "updated"
+            items.append({
+                "kind": "page",
+                "label": f"Page {verb}",
+                "title": page.title or page.path.replace(".md", "").rsplit("/", 1)[-1],
+                "detail": page.path,
+                "url": _page_url(owner.username, wiki.slug, page.path),
+                "actor": page.author if not page.anonymous else "anonymous",
+                "timestamp": _activity_time(page.updated_at),
+                "visibility": page.visibility,
+            })
+
+    if _is_owner(wiki) or current_user.is_authenticated:
+        proposals = (
+            Proposal.query.filter_by(wiki_id=wiki.id)
+            .order_by(Proposal.updated_at.desc())
+            .limit(50)
+            .all()
+        )
+        for proposal in proposals:
+            if not _viewer_can_see_proposal(proposal, owner, wiki):
+                continue
+            items.append({
+                "kind": "proposal",
+                "label": f"Suggestion {proposal.status.replace('_', ' ')}",
+                "title": proposal.title,
+                "detail": proposal.page_path,
+                "url": url_for("wiki.proposal_detail", username=owner.username, slug=wiki.slug, proposal_id=proposal.id),
+                "actor": proposal.author_name or "anonymous",
+                "timestamp": _activity_time(proposal.updated_at),
+                "visibility": "private" if proposal.status != "accepted" else None,
+            })
+            comment = proposal.comments.order_by(None).order_by(ProposalComment.created_at.desc()).first()
+            if comment:
+                items.append({
+                    "kind": "comment",
+                    "label": comment.event.replace("_", " ").title(),
+                    "title": proposal.title,
+                    "detail": (comment.body or "")[:140],
+                    "url": url_for("wiki.proposal_detail", username=owner.username, slug=wiki.slug, proposal_id=proposal.id),
+                    "actor": comment.author_name or "anonymous",
+                    "timestamp": _activity_time(comment.created_at),
+                    "visibility": None,
+                })
+
+    if visible_pages:
+        user_ids = set()
+        stars = Star.query.filter_by(wiki_id=wiki.id).order_by(Star.created_at.desc()).limit(25).all()
+        forks = Fork.query.filter_by(source_wiki_id=wiki.id).order_by(Fork.created_at.desc()).limit(25).all()
+        user_ids.update(star.user_id for star in stars)
+        user_ids.update(fork.user_id for fork in forks)
+        users = {u.id: u for u in User.query.filter(User.id.in_(user_ids)).all()} if user_ids else {}
+
+        for star in stars:
+            actor = users.get(star.user_id)
+            items.append({
+                "kind": "star",
+                "label": "Wiki starred",
+                "title": wiki.title or wiki.slug,
+                "detail": f"@{actor.username}" if actor else "Someone",
+                "url": f"/@{owner.username}/{wiki.slug}",
+                "actor": actor.username if actor else None,
+                "timestamp": _activity_time(star.created_at),
+                "visibility": None,
+            })
+
+        for fork in forks:
+            actor = users.get(fork.user_id)
+            forked_wiki = db.session.get(Wiki, fork.forked_wiki_id)
+            fork_url = f"/@{actor.username}/{forked_wiki.slug}" if actor and forked_wiki else f"/@{owner.username}/{wiki.slug}"
+            items.append({
+                "kind": "fork",
+                "label": "Wiki forked",
+                "title": wiki.title or wiki.slug,
+                "detail": f"@{actor.username}/{forked_wiki.slug}" if actor and forked_wiki else "Fork created",
+                "url": fork_url,
+                "actor": actor.username if actor else None,
+                "timestamp": _activity_time(fork.created_at),
+                "visibility": None,
+            })
+
+    return sorted(items, key=lambda item: item["timestamp"], reverse=True)[:limit]
 
 
 def _folder_listing(username, slug, wiki, folder_path="", public=False, acl_filter_user=None):
@@ -1286,6 +1399,25 @@ def wiki_history(username, slug):
     # filter out internal event log commits (noise)
     commits = [c for c in raw_commits if not c["message"].startswith("Log ")]
     return render_template("folder.html", owner=owner, wiki=wiki, items=[], sidebar_items=_sidebar_for_wiki(owner.username, wiki.slug, wiki, public=use_public), folder_path="history", rendered_html=None, breadcrumb=[("History", None)], history_commits=commits)
+
+
+@wiki_bp.route("/@<username>/<slug>/activity")
+def wiki_activity(username, slug):
+    """Recent wiki activity, filtered to what the current viewer may know."""
+    owner, wiki, _ = _get_owner_and_wiki_or_404(username, slug)
+    acl_rules = load_acl_rules(owner.username, wiki.slug)
+    if not _viewer_can_see_any_page(wiki, acl_rules=acl_rules, owner=owner):
+        return _render_permission_error(owner, wiki)
+    use_public, acl_filter_user = _repo_access(wiki, acl_rules)
+    return render_template(
+        "activity.html",
+        owner=owner,
+        wiki=wiki,
+        activity_items=_wiki_activity_items(owner, wiki, acl_rules),
+        sidebar_items=_sidebar_for_wiki(owner.username, wiki.slug, wiki, public=use_public, current_path="activity", acl_filter_user=acl_filter_user),
+        recently_updated=_recently_updated_pages(wiki, public_only=use_public and not acl_filter_user),
+        sibling_wikis=_sibling_wikis(owner, wiki),
+    )
 
 
 @wiki_bp.route("/@<username>/<slug>/<path:folder_path>/history")

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -1,0 +1,115 @@
+{% extends "base.html" %}
+{% block title %}Activity - {{ wiki.title or wiki.slug }} - wikihub{% endblock %}
+
+{% block extra_css %}
+.activity-shell { display: flex; min-height: calc(100vh - 56px); }
+.sidebar { width: 280px; flex-shrink: 0; border-right: 1px solid var(--border-default); padding: 16px 0; overflow-y: auto; overflow-x: hidden; display: none; }
+@media (min-width: 768px) { .sidebar { display: block; } }
+.sidebar-section { padding: 0 8px; margin-bottom: 16px; }
+.sidebar-heading { font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); padding: 6px 12px; margin-bottom: 2px; }
+.sidebar-item { display: flex; align-items: center; gap: 8px; padding: 5px 8px; border-radius: var(--radius-sm); font-size: 0.8125rem; color: var(--text-tertiary); text-decoration: none; margin-bottom: 1px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.sidebar-item:hover, .sidebar-item.active { color: var(--text-primary); background: var(--accent-subtle); text-decoration: none; }
+.sidebar-item.active { border-left: 2px solid var(--accent); }
+.sidebar-icon { flex-shrink: 0; color: var(--text-muted); }
+.activity-main { flex: 1; min-width: 0; padding: 32px 16px 72px; }
+@media (min-width: 760px) { .activity-main { padding: 44px 48px 80px; } }
+.activity-inner { max-width: 880px; }
+.breadcrumb { font-size: 0.8125rem; color: var(--text-tertiary); margin-bottom: 20px; font-family: var(--font-mono); display: flex; align-items: center; flex-wrap: wrap; gap: 4px; }
+.breadcrumb a { color: var(--text-tertiary); }
+.activity-title { font-size: 1.75rem; line-height: 1.15; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 8px; }
+.activity-subtitle { color: var(--text-secondary); font-size: 0.9375rem; margin-bottom: 28px; max-width: 620px; }
+.activity-list { border: 1px solid var(--border-default); border-radius: var(--radius-md); overflow: hidden; background: var(--bg-surface); }
+.activity-row { display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; gap: 14px; align-items: start; padding: 14px 16px; color: var(--text-primary); text-decoration: none; border-bottom: 1px solid var(--border-default); }
+.activity-row:last-child { border-bottom: none; }
+.activity-row:hover { background: var(--accent-subtle); text-decoration: none; }
+.activity-mark { width: 28px; height: 28px; border: 1px solid var(--border-emphasis); border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; color: var(--accent); background: var(--control-bg); font-family: var(--font-mono); font-size: 0.75rem; }
+.activity-copy { min-width: 0; }
+.activity-label { display: block; font-size: 0.6875rem; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 2px; }
+.activity-name { display: block; font-weight: 600; color: var(--text-primary); overflow-wrap: anywhere; }
+.activity-detail { display: block; color: var(--text-secondary); font-size: 0.8125rem; margin-top: 2px; overflow-wrap: anywhere; }
+.activity-meta { display: flex; flex-direction: column; align-items: flex-end; gap: 6px; color: var(--text-muted); font-family: var(--font-mono); font-size: 0.75rem; white-space: nowrap; }
+.activity-vis { font-family: var(--font-body); font-size: 0.6875rem; padding: 2px 7px; border: 1px solid var(--border-emphasis); border-radius: var(--radius-sm); color: var(--text-tertiary); }
+.activity-vis.public, .activity-vis.public-view, .activity-vis.public-edit { color: var(--color-public); border-color: rgba(var(--rgb-public), 0.25); }
+.activity-vis.private { color: var(--color-private); border-color: rgba(var(--rgb-private), 0.25); }
+.activity-empty { border: 1px solid var(--border-default); border-radius: var(--radius-md); padding: 24px; color: var(--text-secondary); background: var(--bg-surface); }
+@media (max-width: 640px) {
+  .activity-row { grid-template-columns: 30px minmax(0, 1fr); }
+  .activity-meta { grid-column: 2; flex-direction: row; align-items: center; justify-content: flex-start; }
+}
+{% endblock %}
+
+{% block body %}
+<div class="activity-shell">
+  <aside class="sidebar">
+    <div class="sidebar-section">
+      <a href="/@{{ owner.username }}/{{ wiki.slug }}" class="sidebar-heading" style="text-decoration:none;display:block;">{{ wiki.title or wiki.slug }}</a>
+      <a href="/@{{ owner.username }}/{{ wiki.slug }}/activity" class="sidebar-item active">
+        <span class="sidebar-icon">+</span>
+        Activity
+      </a>
+      <a href="/@{{ owner.username }}/{{ wiki.slug }}/history" class="sidebar-item">
+        <span class="sidebar-icon">#</span>
+        History
+      </a>
+      {% if current_user.is_authenticated and current_user.id == wiki.owner_id %}
+      <a href="/@{{ owner.username }}/{{ wiki.slug }}/new" class="sidebar-item" style="color:var(--accent);margin-top:8px;">New page</a>
+      {% endif %}
+    </div>
+    {% if recently_updated %}
+    <div class="sidebar-section" style="border-top:1px solid var(--border-default);padding-top:12px;">
+      <div class="sidebar-heading">Recently updated</div>
+      {% for rp in recently_updated[:8] %}
+      <a href="/@{{ owner.username }}/{{ wiki.slug }}/{{ rp.path | page_url }}" class="sidebar-item" title="{{ rp.path }}">
+        <span style="color:var(--text-muted);font-size:0.6875rem;font-family:var(--font-mono);min-width:38px;">{{ rp.updated_at.strftime('%m/%d') if rp.updated_at else '' }}</span>
+        {{ rp.title or rp.path.replace('.md', '').split('/')[-1] }}
+      </a>
+      {% endfor %}
+    </div>
+    {% endif %}
+    {% if sibling_wikis %}
+    <div class="sidebar-section" style="border-top:1px solid var(--border-default);padding-top:12px;">
+      <div class="sidebar-heading">{{ owner.display_name or owner.username }}'s Wikis</div>
+      {% for w in sibling_wikis %}
+      <a href="/@{{ owner.username }}/{{ w.slug }}" class="sidebar-item">{{ w.title or w.slug }}</a>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </aside>
+
+  <main class="activity-main">
+    <div class="activity-inner">
+      <div class="breadcrumb">
+        <a href="/@{{ owner.username }}">@{{ owner.username }}</a>
+        <span>/</span>
+        <a href="/@{{ owner.username }}/{{ wiki.slug }}">{{ wiki.title or wiki.slug }}</a>
+        <span>/ activity</span>
+      </div>
+      <h1 class="activity-title">Activity</h1>
+      <p class="activity-subtitle">Recent visible edits, suggestions, stars, and forks for this wiki.</p>
+
+      {% if activity_items %}
+      <div class="activity-list">
+        {% for item in activity_items %}
+        <a href="{{ item.url }}" class="activity-row">
+          <span class="activity-mark" aria-hidden="true">
+            {% if item.kind == "page" %}P{% elif item.kind == "proposal" %}S{% elif item.kind == "comment" %}C{% elif item.kind == "star" %}*{% elif item.kind == "fork" %}F{% else %}+{% endif %}
+          </span>
+          <span class="activity-copy">
+            <span class="activity-label">{{ item.label }}</span>
+            <span class="activity-name">{{ item.title }}</span>
+            {% if item.detail %}<span class="activity-detail">{{ item.detail }}</span>{% endif %}
+          </span>
+          <span class="activity-meta">
+            <time datetime="{{ item.timestamp.isoformat() }}">{{ item.timestamp.strftime('%Y-%m-%d') }}</time>
+            {% if item.visibility %}<span class="activity-vis {{ item.visibility }}">{{ item.visibility }}</span>{% endif %}
+          </span>
+        </a>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="activity-empty">No visible activity yet.</div>
+      {% endif %}
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/app/templates/folder.html
+++ b/app/templates/folder.html
@@ -114,6 +114,10 @@
       </div>
       {% endif %}
       </div>
+      <a href="/@{{ owner.username }}/{{ wiki.slug }}/activity" class="sidebar-item" style="margin-top:8px;">
+        <span class="sidebar-icon" style="font-family:var(--font-mono);font-size:0.75rem;">+</span>
+        Activity
+      </a>
       {% if current_user.is_authenticated and current_user.id == wiki.owner_id %}
       <a href="/@{{ owner.username }}/{{ wiki.slug }}/new{% if folder_path %}?path={{ (folder_path ~ '/') | urlencode }}{% endif %}" class="sidebar-item" style="color:var(--accent);margin-top:8px;">New page</a>
       <a href="/@{{ owner.username }}/{{ wiki.slug }}/new-folder{% if folder_path %}?parent={{ folder_path | urlencode }}{% endif %}" class="sidebar-item" style="color:var(--accent);">New folder</a>

--- a/app/templates/reader.html
+++ b/app/templates/reader.html
@@ -716,6 +716,10 @@
       </div>
       {% endif %}
       </div>
+      <a href="/@{{ owner.username }}/{{ wiki.slug }}/activity" class="sidebar-item" style="margin-top:8px;">
+        <span class="sidebar-icon" style="font-family:var(--font-mono);font-size:0.75rem;">+</span>
+        Activity
+      </a>
       {% if current_user.is_authenticated and current_user.id == wiki.owner_id %}
       <a href="/@{{ owner.username }}/{{ wiki.slug }}/new" class="sidebar-item" style="color:var(--accent);margin-top:8px;">
         <span class="sidebar-icon" style="color:var(--accent);">
@@ -1077,6 +1081,7 @@
   {% endif %}
 </div>
 
+{% if curator_enabled and current_user.is_authenticated %}
 <!-- Curator AI sidebar -->
 <button class="curator-toggle" onclick="toggleCurator()" title="Open Curator" aria-label="Open Curator">
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
@@ -1089,6 +1094,7 @@
   <div class="curator-messages" id="curator-messages">
     <div class="curator-message assistant">
       I'm the Curator. I can help you navigate, organize, and curate this wiki. What would you like to do?
+      <p style="margin-top:8px;color:var(--text-tertiary);font-size:0.8125rem;">If I need credentials, connect Claude or add an API key in <a href="/settings" style="color:var(--accent);">Settings</a>.</p>
     </div>
   </div>
   <div class="curator-input-area">
@@ -1097,6 +1103,7 @@
   </div>
 </div>
 <div class="curator-overlay" id="curator-overlay" onclick="toggleCurator()"></div>
+{% endif %}
 
 {% endblock %}
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -617,6 +617,95 @@ def test_social(client, api_key):
     assert r.status_code == 200
 
 
+def test_activity_feed_filters_private_and_shows_social_events(client, api_key):
+    """Wiki activity renders recent page/social events without leaking private pages."""
+    h = {"Authorization": f"Bearer {api_key}"}
+    r = client.post("/api/v1/wikis", json={"slug": "activity-check", "title": "Activity Check"}, headers=h)
+    assert r.status_code == 201
+
+    r = client.post("/api/v1/wikis/agent1/activity-check/pages", json={
+        "path": "wiki/public-activity.md",
+        "content": "---\ntitle: Public Activity\nvisibility: public\n---\n\n# Public Activity\n",
+        "visibility": "public",
+    }, headers=h)
+    assert r.status_code == 201
+    r = client.post("/api/v1/wikis/agent1/activity-check/pages", json={
+        "path": "secrets/private-activity.md",
+        "content": "# Private Activity\n\nSecret feed item.",
+        "visibility": "private",
+    }, headers=h)
+    assert r.status_code == 201
+
+    r = client.post("/api/v1/accounts", json={"username": "activityfan"})
+    assert r.status_code == 201
+    fan_key = r.get_json()["api_key"]
+    fan_h = {"Authorization": f"Bearer {fan_key}"}
+    r = client.post("/api/v1/wikis/agent1/activity-check/star", headers=fan_h)
+    assert r.status_code == 201
+    r = client.post("/api/v1/wikis/agent1/activity-check/fork", headers=fan_h)
+    assert r.status_code == 201
+
+    anon = client.application.test_client()
+    r = anon.get("/@agent1/activity-check/activity")
+    assert r.status_code == 200, f"activity feed should be public when public pages exist, got {r.status_code}"
+    html = r.get_data(as_text=True)
+    assert "Activity" in html
+    assert "Public Activity" in html
+    assert "Wiki starred" in html
+    assert "Wiki forked" in html
+    assert "Private Activity" not in html
+    assert "secrets/private-activity.md" not in html
+
+    owner_browser = client.application.test_client()
+    r = owner_browser.post("/auth/login", data={"api_key": api_key}, follow_redirects=False)
+    assert r.status_code == 302
+    r = owner_browser.get("/@agent1/activity-check/activity")
+    assert r.status_code == 200
+    owner_html = r.get_data(as_text=True)
+    assert "Private Activity" in owner_html
+    assert "secrets/private-activity.md" in owner_html
+
+    r = owner_browser.get("/@agent1/activity-check/wiki/public-activity")
+    assert r.status_code == 200
+    assert b"/@agent1/activity-check/activity" in r.data
+
+
+def test_curator_sidebar_only_renders_when_usable(app, client, api_key):
+    """Curator launcher should not appear for anon/disabled contexts."""
+    h = {"Authorization": f"Bearer {api_key}"}
+    r = client.post("/api/v1/wikis", json={"slug": "curator-ui", "title": "Curator UI"}, headers=h)
+    assert r.status_code == 201
+    r = client.post("/api/v1/wikis/agent1/curator-ui/pages", json={
+        "path": "wiki/page.md",
+        "content": "---\ntitle: Curator Page\nvisibility: public\n---\n\n# Curator Page\n",
+        "visibility": "public",
+    }, headers=h)
+    assert r.status_code == 201
+
+    original = app.config.get("CURATOR_ENABLED", True)
+    try:
+        app.config["CURATOR_ENABLED"] = True
+        anon = client.application.test_client()
+        r = anon.get("/@agent1/curator-ui/wiki/page")
+        assert r.status_code == 200
+        assert b"class=\"curator-toggle\"" not in r.data
+
+        browser = client.application.test_client()
+        r = browser.post("/auth/login", data={"api_key": api_key}, follow_redirects=False)
+        assert r.status_code == 302
+        r = browser.get("/@agent1/curator-ui/wiki/page")
+        assert r.status_code == 200
+        assert b"class=\"curator-toggle\"" in r.data
+        assert b"connect Claude or add an API key" in r.data
+
+        app.config["CURATOR_ENABLED"] = False
+        r = browser.get("/@agent1/curator-ui/wiki/page")
+        assert r.status_code == 200
+        assert b"class=\"curator-toggle\"" not in r.data
+    finally:
+        app.config["CURATOR_ENABLED"] = original
+
+
 def test_zip_upload(client, api_key):
     """create wiki via zip upload"""
     # login via web
@@ -5201,6 +5290,8 @@ def run_all():
             ("reader owner visibility control", lambda: test_reader_owner_visibility_control(client, key)),
             ("search respects ACL shares", lambda: test_search_respects_acl_shares(client, key)),
             ("social (star + fork)", lambda: test_social(client, key)),
+            ("activity feed filters private and shows social events", lambda: test_activity_feed_filters_private_and_shows_social_events(client, key)),
+            ("curator sidebar only renders when usable", lambda: test_curator_sidebar_only_renders_when_usable(app, client, key)),
             ("zip upload", lambda: test_zip_upload(client, key)),
             ("anonymous upload (wikihub-i2xm)", lambda: test_anonymous_upload(app)),
             ("agent surfaces", lambda: test_agent_surfaces(client)),


### PR DESCRIPTION
## Summary
- Add /@owner/wiki/activity as a wiki activity feed composed from existing page, proposal/comment, star, and fork rows.
- Filter feed items through the same ACL checks used by reader/history routes so anonymous viewers do not see private page activity.
- Link Activity from wiki sidebars and gate the Curator launcher to authenticated + CURATOR_ENABLED contexts, with Settings guidance for credentials.

## Verification
- PASS: python3 -m py_compile app/routes/wiki.py
- PASS: git diff --check
- BLOCKED: uv run --with-requirements requirements.txt python3 tests/test_e2e.py installed requirements, then hung after PASS agent account creation during test_wiki_lifecycle; interrupted stack was in delete_page -> append_event_to_repo -> sync_page_to_repo -> apply_repo_changes -> git update-index for .wikihub/events.jsonl.
- BLOCKED: no-mistakes axi run failed before starting with: no run started for "wikihub-activity-sidebar-r1": no previous run for branch wikihub-activity-sidebar-r1. Retried with --yes and got the same error.

Do not merge automatically.