### PR TITLE
feat(reader): Notion-style side peek for internal links (wikihub-9k18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ source .venv/bin/activate && python3 tests/test_e2e.py
 
 tests use a separate `wikihub_test` database. create it once: `/opt/homebrew/opt/postgresql@16/bin/createdb wikihub_test`.
 
-tests are minimal and intentional — each one verifies a real user flow end-to-end, not individual functions:
+tests are intentional — each one verifies a real user flow end-to-end or a browser-facing regression, not isolated helper internals. Core flows include:
 
 1. **agent account creation** — POST /api/v1/accounts, get key, authenticate
 2. **wiki lifecycle** — create wiki, add page, read HTML + markdown, update, delete
@@ -30,6 +30,7 @@ tests are minimal and intentional — each one verifies a real user flow end-to-
 5. **zip upload** — create wiki via web form with zip file
 6. **agent surfaces** — all discovery endpoints respond (llms.txt, AGENTS.md, .well-known/*)
 7. **ACL permissions** — private pages not readable without auth
+8. **reader behavior** — sidebar, page controls, side peek, and other browser-facing regressions
 
 don't add unit tests for individual functions. if something breaks, add an e2e test that covers the broken flow. tests should run in <10 seconds.
 
@@ -82,6 +83,7 @@ host (`ubuntu@54.145.123.7`) — that's historical. Production is GCP now.
 - `app/git_backend.py` — git Smart HTTP (clone/push), ported from listhub
 - `app/git_sync.py` — DB→git plumbing (does NOT fire hooks), public mirror regeneration
 - `app/renderer.py` — markdown-it-py with wikilinks, KaTeX, footnotes, Obsidian embeds
+- `app/static/js/sidepeek.js` — desktop reader slide-over for same-wiki page links; fetches rendered body JSON via `?fragment=1`
 - `app/auth_utils.py` — password hashing, API key gen/verify, Bearer auth decorators
 - `app/routes/` — blueprints: main, auth, api, api_wikis, wiki, agent_surfaces, upload
 - `hooks/post-receive` — git→DB sync (installed into each wiki's bare repo)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GitHub for LLM wikis. A hosting platform for markdown knowledge bases with per-f
 - Agent-native: REST API, MCP server, content negotiation, `llms.txt`
 - Social: fork, star, explore, profiles
 - Rendering: KaTeX math, syntax highlighting, wikilinks, footnotes, Obsidian embeds
+- Reader side peek: same-wiki page links open in a right-side preview panel on desktop
 - Every wiki is a real git repo — clone, push, blame, bisect
 
 ## Quick start
@@ -58,6 +59,8 @@ Authorization: Bearer wh_...
 ```
 
 Content negotiation: `Accept: text/markdown` on any page URL returns raw markdown. Or append `.md`.
+For the desktop reader side peek, append `?fragment=1` to a rendered page URL to get JSON
+`{title, html, url, path}` for the article body only; the route uses the same page ACL checks.
 
 Full docs at `/agents` when running.
 
@@ -118,7 +121,8 @@ createdb wikihub_test  # once
 source .venv/bin/activate && python3 tests/test_e2e.py
 ```
 
-7 end-to-end tests covering account creation, wiki lifecycle, search, social, upload, agent surfaces, and ACL permissions.
+End-to-end tests cover account creation, wiki lifecycle, search, social, upload,
+agent surfaces, ACL permissions, reader behavior, and regression cases.
 
 ## Architecture
 

--- a/app/routes/agent_surfaces.py
+++ b/app/routes/agent_surfaces.py
@@ -496,6 +496,10 @@ Auth order: `--api-key` flag → `WIKIHUB_*` env vars → `~/.wikihub/credential
 `Accept: text/markdown` on any page URL returns raw markdown.
 Or append `.md` to the URL.
 
+For rendered HTML without the full reader chrome, append `?fragment=1` to a
+page URL. The response is JSON `{title, html, url, path}` for the article body
+only and uses the same ACL checks as the full page route.
+
 ## hosting non-markdown files
 
 You can store any file (images, PDFs, CSV, HTML, etc.) in a wiki and it is

--- a/app/routes/wiki.py
+++ b/app/routes/wiki.py
@@ -1770,7 +1770,10 @@ def wiki_page(username, slug, page_path):
     # .md in URL: browsers get redirected to the clean HTML URL,
     # API clients requesting text/markdown get raw markdown.
     if page_path.endswith(".md") and not wants_markdown:
-        return redirect(f"/@{owner.username}/{wiki.slug}/{html_url_path}", code=302)
+        redirect_url = f"/@{owner.username}/{wiki.slug}/{html_url_path}"
+        if request.args.get("fragment"):
+            redirect_url += "?fragment=1"
+        return redirect(redirect_url, code=302)
     if wants_markdown:
         return Response(
             content,

--- a/app/routes/wiki.py
+++ b/app/routes/wiki.py
@@ -1785,6 +1785,25 @@ def wiki_page(username, slug, page_path):
         page = type("Page", (), {"path": file_path, "title": os.path.basename(file_path).replace(".md", ""), "visibility": resolve_visibility(file_path, acl_rules), "updated_at": wiki.updated_at})()
 
     rendered_html = render_page(content, owner.username, wiki.slug, current_page_path=file_path)
+
+    # Side peek (wikihub-9k18): ?fragment=1 returns the rendered article body
+    # only (no chrome) so a reader can open a same-wiki link in a slide-over
+    # panel without navigating away. This flows through the SAME ACL checks
+    # above (private pages already abort 404 before reaching here), so the
+    # fragment endpoint never leaks private content the full page wouldn't.
+    if request.args.get("fragment"):
+        from flask import jsonify
+        page_title = getattr(page, "title", None) or os.path.basename(file_path).replace(".md", "")
+        canonical = f"/@{owner.username}/{wiki.slug}/{html_url_path}"
+        resp = jsonify({
+            "title": page_title,
+            "html": rendered_html,
+            "url": canonical,
+            "path": html_url_path,
+        })
+        resp.headers["Cache-Control"] = "no-store"
+        return resp
+
     page_grants = resolve_grants(file_path, acl_rules) if is_owner else []
     user_can_edit = is_owner or can_write(file_path, acl_rules, user_name, page.visibility if page else None)
     pending_proposals_count = 0

--- a/app/static/js/sidepeek.js
+++ b/app/static/js/sidepeek.js
@@ -85,9 +85,7 @@
     overlay.setAttribute("hidden", "");
   }
 
-  // Load `rest` (a page path relative to wikiBase, may include #hash) into the
-  // peek. When push is true, add a history entry so back/close pops it.
-  function loadPeek(rest, push) {
+  function loadPeek(rest, historyMode) {
     build();
     var hash = "";
     var hi = rest.indexOf("#");
@@ -114,9 +112,14 @@
         currentPeekPath = new URL(currentFullUrl).pathname;
         openLink.href = data.url;
         rehydrate(bodyEl);
-        if (push) {
+        if (historyMode) {
           var q = location.pathname + "?peek=" + encodeURIComponent(rest);
-          history.pushState({ peek: rest }, "", q);
+          var state = { peek: rest };
+          if (historyMode === "replace") {
+            history.replaceState(history.state && history.state.peek ? state : null, "", q);
+          } else {
+            history.pushState(state, "", q);
+          }
         }
         showDom();
         if (hash) {
@@ -217,13 +220,13 @@
     if (a.hasAttribute("download")) return;
     var href = a.getAttribute("href") || "";
     if (href.charAt(0) === "#") return;
+    var inPeek = !!a.closest(".peek-body");
     var url;
     try {
-      url = new URL(a.href, location.href);
+      url = new URL(href, inPeek && currentFullUrl ? currentFullUrl : location.href);
     } catch (err) {
       return;
     }
-    var inPeek = !!a.closest(".peek-body");
     var currentPath = location.pathname;
     if (inPeek && currentPeekPath) {
       currentPath = currentPeekPath;
@@ -240,7 +243,7 @@
     if (!rest || rest.indexOf("/-/") >= 0) return; // proposals / suggest etc.
     if (isMobile()) return; // small screens: normal navigation
     e.preventDefault();
-    loadPeek(rest + url.hash, true);
+    loadPeek(rest + url.hash, inPeek ? "replace" : "push");
   }
 
   window.addEventListener("popstate", function () {

--- a/app/static/js/sidepeek.js
+++ b/app/static/js/sidepeek.js
@@ -1,0 +1,230 @@
+/* Side peek (wikihub-9k18) — Notion-style slide-over for internal wiki links.
+ *
+ * Clicking a normal (unmodified) same-wiki page link inside the article opens
+ * the target page in a right-side panel instead of navigating away, so the
+ * reader keeps their place. Modified clicks (cmd/ctrl/shift/alt/middle) and
+ * external / broken links keep their default behavior. The panel content is
+ * the server-rendered article body fetched from `?fragment=1` (one shared
+ * renderer + ACL path — no client-side duplication, no private-content leak).
+ *
+ * Deep-linkable: `?peek=<page-path>` restores the peek on load and is pushed
+ * to history when a peek opens, so the browser back button (and the close
+ * controls) close it and the URL is shareable.
+ *
+ * One level only: navigating a link inside the peek replaces the panel content
+ * (it never spawns a second stacked panel). Below the mobile breakpoint peeks
+ * are disabled and links navigate normally.
+ */
+(function () {
+  "use strict";
+  var cfg = window.__wikihubPeek;
+  if (!cfg || !cfg.base) return;
+  var wikiBase = cfg.base; // "/@owner/slug"
+  var MOBILE_MAX = 767;
+
+  function isMobile() {
+    return window.innerWidth <= MOBILE_MAX;
+  }
+
+  var overlay, panel, bodyEl, titleEl, openLink, copyBtn;
+  var currentFullUrl = null;
+
+  function build() {
+    if (overlay) return;
+    overlay = document.createElement("div");
+    overlay.className = "peek-overlay";
+    overlay.setAttribute("hidden", "");
+    overlay.innerHTML =
+      '<div class="peek-panel" role="dialog" aria-modal="true" aria-label="Page preview">' +
+      '  <div class="peek-head">' +
+      '    <div class="peek-title" id="peek-title"></div>' +
+      '    <div class="peek-actions">' +
+      '      <a class="peek-btn peek-open" title="Open as full page" aria-label="Open as full page">' +
+      '        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7"/><path d="M8 7h9v9"/></svg>' +
+      '      </a>' +
+      '      <button type="button" class="peek-btn peek-copy" title="Copy link" aria-label="Copy link">' +
+      '        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>' +
+      '      </button>' +
+      '      <button type="button" class="peek-btn peek-close" title="Close (Esc)" aria-label="Close preview">' +
+      '        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="M6 6l12 12"/></svg>' +
+      '      </button>' +
+      '    </div>' +
+      '  </div>' +
+      '  <div class="peek-body article thin-scroll" id="peek-body"></div>' +
+      "</div>";
+    document.body.appendChild(overlay);
+    panel = overlay.querySelector(".peek-panel");
+    bodyEl = overlay.querySelector("#peek-body");
+    titleEl = overlay.querySelector("#peek-title");
+    openLink = overlay.querySelector(".peek-open");
+    copyBtn = overlay.querySelector(".peek-copy");
+
+    overlay.addEventListener("click", function (e) {
+      if (e.target === overlay) closePeek();
+    });
+    overlay.querySelector(".peek-close").addEventListener("click", closePeek);
+    copyBtn.addEventListener("click", onCopy);
+    // Links clicked inside the peek navigate within the peek (one level).
+    bodyEl.addEventListener("click", onLinkClick);
+  }
+
+  function showDom() {
+    build();
+    overlay.removeAttribute("hidden");
+    // force reflow so the CSS transition runs on the added class
+    void overlay.offsetWidth;
+    overlay.classList.add("open");
+    document.body.classList.add("peek-open");
+  }
+
+  function hideDom() {
+    if (!overlay) return;
+    overlay.classList.remove("open");
+    document.body.classList.remove("peek-open");
+    overlay.setAttribute("hidden", "");
+  }
+
+  // Load `rest` (a page path relative to wikiBase, may include #hash) into the
+  // peek. When push is true, add a history entry so back/close pops it.
+  function loadPeek(rest, push) {
+    build();
+    var hash = "";
+    var hi = rest.indexOf("#");
+    if (hi >= 0) {
+      hash = rest.slice(hi);
+      rest = rest.slice(0, hi);
+    }
+    var pageUrl = wikiBase + "/" + rest;
+    var fragUrl = pageUrl + (pageUrl.indexOf("?") >= 0 ? "&" : "?") + "fragment=1";
+
+    fetch(fragUrl, { headers: { Accept: "application/json" }, credentials: "same-origin" })
+      .then(function (r) {
+        var ct = r.headers.get("content-type") || "";
+        if (!r.ok || ct.indexOf("application/json") < 0) {
+          throw new Error("not a peekable page");
+        }
+        return r.json();
+      })
+      .then(function (data) {
+        titleEl.textContent = data.title || rest;
+        bodyEl.innerHTML = data.html || "";
+        bodyEl.scrollTop = 0;
+        currentFullUrl = new URL(data.url, location.href).href;
+        openLink.href = data.url;
+        rehydrate(bodyEl);
+        if (push) {
+          var q = location.pathname + "?peek=" + encodeURIComponent(rest);
+          history.pushState({ peek: rest }, "", q);
+        }
+        showDom();
+        if (hash) {
+          var t = bodyEl.querySelector(hash.replace(/[^#\w\-:.]/g, ""));
+          if (t) t.scrollIntoView();
+        }
+      })
+      .catch(function () {
+        // Not a peekable target (missing, private, non-markdown, network) —
+        // fall back to a normal full-page navigation.
+        window.location.href = pageUrl + hash;
+      });
+  }
+
+  // Re-run optional in-content rendering (KaTeX) on freshly injected HTML.
+  function rehydrate(el) {
+    if (typeof window.renderMathInElement === "function") {
+      try {
+        window.renderMathInElement(el, {
+          delimiters: [
+            { left: "$$", right: "$$", display: true },
+            { left: "$", right: "$", display: false },
+          ],
+          throwOnError: false,
+        });
+      } catch (e) {}
+    }
+  }
+
+  function onCopy() {
+    if (!currentFullUrl) return;
+    var done = function () {
+      copyBtn.classList.add("copied");
+      setTimeout(function () {
+        copyBtn.classList.remove("copied");
+      }, 1200);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(currentFullUrl).then(done, done);
+    } else {
+      var ta = document.createElement("textarea");
+      ta.value = currentFullUrl;
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand("copy");
+      } catch (e) {}
+      document.body.removeChild(ta);
+      done();
+    }
+  }
+
+  // Close via X / Esc / click-outside. If a history entry was pushed for the
+  // peek, pop it (keeps history clean + syncs the URL); otherwise just hide.
+  function closePeek() {
+    if (history.state && history.state.peek) {
+      history.back();
+    } else {
+      hideDom();
+      if (new URLSearchParams(location.search).has("peek")) {
+        history.replaceState(null, "", location.pathname);
+      }
+    }
+  }
+
+  function onLinkClick(e) {
+    if (e.defaultPrevented) return;
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    var a = e.target.closest("a");
+    if (!a) return;
+    // Only content links that live in the article or the peek body.
+    if (!a.closest(".article, .peek-body")) return;
+    if (a.target && a.target !== "" && a.target !== "_self") return;
+    if (a.classList.contains("external-link") || a.classList.contains("wikilink-broken")) return;
+    if (a.hasAttribute("download")) return;
+    var url;
+    try {
+      url = new URL(a.href, location.href);
+    } catch (err) {
+      return;
+    }
+    if (url.origin !== location.origin) return;
+    if (!url.pathname.startsWith(wikiBase + "/")) return;
+    var rest = url.pathname.slice(wikiBase.length + 1);
+    if (!rest || rest.indexOf("/-/") >= 0) return; // proposals / suggest etc.
+    if (isMobile()) return; // small screens: normal navigation
+    e.preventDefault();
+    loadPeek(rest + url.hash, true);
+  }
+
+  window.addEventListener("popstate", function () {
+    var p = new URLSearchParams(location.search).get("peek");
+    if (p) {
+      loadPeek(p, false);
+    } else {
+      hideDom();
+    }
+  });
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape" && overlay && overlay.classList.contains("open")) {
+      closePeek();
+    }
+  });
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var main = document.querySelector(".reader-layout .article") || document.querySelector(".article");
+    if (main) main.addEventListener("click", onLinkClick);
+    // Restore a deep-linked peek.
+    var p = new URLSearchParams(location.search).get("peek");
+    if (p && !isMobile()) loadPeek(p, false);
+  });
+})();

--- a/app/static/js/sidepeek.js
+++ b/app/static/js/sidepeek.js
@@ -29,6 +29,7 @@
   var overlay, panel, bodyEl, titleEl, openLink, copyBtn;
   var currentFullUrl = null;
   var currentPeekPath = null;
+  var loadRequestSeq = 0;
 
   function build() {
     if (overlay) return;
@@ -79,6 +80,7 @@
   }
 
   function hideDom() {
+    loadRequestSeq++;
     if (!overlay) return;
     overlay.classList.remove("open");
     document.body.classList.remove("peek-open");
@@ -87,6 +89,7 @@
 
   function loadPeek(rest, historyMode) {
     build();
+    var requestId = ++loadRequestSeq;
     var hash = "";
     var hi = rest.indexOf("#");
     if (hi >= 0) {
@@ -98,6 +101,7 @@
 
     fetch(fragUrl, { headers: { Accept: "application/json" }, credentials: "same-origin" })
       .then(function (r) {
+        if (requestId !== loadRequestSeq) return null;
         var ct = r.headers.get("content-type") || "";
         if (!r.ok || ct.indexOf("application/json") < 0) {
           throw new Error("not a peekable page");
@@ -105,6 +109,7 @@
         return r.json();
       })
       .then(function (data) {
+        if (requestId !== loadRequestSeq || !data) return;
         titleEl.textContent = data.title || rest;
         bodyEl.innerHTML = data.html || "";
         bodyEl.scrollTop = 0;
@@ -127,6 +132,7 @@
         }
       })
       .catch(function () {
+        if (requestId !== loadRequestSeq) return;
         // Not a peekable target (missing, private, non-markdown, network) —
         // fall back to a normal full-page navigation.
         window.location.href = pageUrl + hash;

--- a/app/static/js/sidepeek.js
+++ b/app/static/js/sidepeek.js
@@ -190,12 +190,19 @@
     if (a.target && a.target !== "" && a.target !== "_self") return;
     if (a.classList.contains("external-link") || a.classList.contains("wikilink-broken")) return;
     if (a.hasAttribute("download")) return;
+    var href = a.getAttribute("href") || "";
+    if (href.charAt(0) === "#") return;
     var url;
     try {
       url = new URL(a.href, location.href);
     } catch (err) {
       return;
     }
+    var currentPath = location.pathname;
+    if (a.closest(".peek-body") && currentFullUrl) {
+      currentPath = new URL(currentFullUrl, location.href).pathname;
+    }
+    if (url.pathname === currentPath) return;
     if (url.origin !== location.origin) return;
     if (!url.pathname.startsWith(wikiBase + "/")) return;
     var rest = url.pathname.slice(wikiBase.length + 1);

--- a/app/static/js/sidepeek.js
+++ b/app/static/js/sidepeek.js
@@ -28,6 +28,7 @@
 
   var overlay, panel, bodyEl, titleEl, openLink, copyBtn;
   var currentFullUrl = null;
+  var currentPeekPath = null;
 
   function build() {
     if (overlay) return;
@@ -110,6 +111,7 @@
         bodyEl.innerHTML = data.html || "";
         bodyEl.scrollTop = 0;
         currentFullUrl = new URL(data.url, location.href).href;
+        currentPeekPath = new URL(currentFullUrl).pathname;
         openLink.href = data.url;
         rehydrate(bodyEl);
         if (push) {
@@ -118,8 +120,7 @@
         }
         showDom();
         if (hash) {
-          var t = bodyEl.querySelector(hash.replace(/[^#\w\-:.]/g, ""));
-          if (t) t.scrollIntoView();
+          scrollPeekHash(hash);
         }
       })
       .catch(function () {
@@ -142,6 +143,30 @@
         });
       } catch (e) {}
     }
+  }
+
+  function findPeekHashTarget(hash) {
+    if (!hash || hash.charAt(0) !== "#") return null;
+    var id;
+    try {
+      id = decodeURIComponent(hash.slice(1));
+    } catch (e) {
+      id = hash.slice(1);
+    }
+    if (!id) return null;
+    if (window.CSS && typeof window.CSS.escape === "function") {
+      return bodyEl.querySelector("#" + window.CSS.escape(id));
+    }
+    var candidates = bodyEl.querySelectorAll("[id]");
+    for (var i = 0; i < candidates.length; i++) {
+      if (candidates[i].id === id) return candidates[i];
+    }
+    return null;
+  }
+
+  function scrollPeekHash(hash) {
+    var t = findPeekHashTarget(hash);
+    if (t) t.scrollIntoView();
   }
 
   function onCopy() {
@@ -198,9 +223,15 @@
     } catch (err) {
       return;
     }
+    var inPeek = !!a.closest(".peek-body");
     var currentPath = location.pathname;
-    if (a.closest(".peek-body") && currentFullUrl) {
-      currentPath = new URL(currentFullUrl, location.href).pathname;
+    if (inPeek && currentPeekPath) {
+      currentPath = currentPeekPath;
+    }
+    if (inPeek && currentPeekPath && url.pathname === currentPeekPath && url.hash) {
+      e.preventDefault();
+      scrollPeekHash(url.hash);
+      return;
     }
     if (url.pathname === currentPath) return;
     if (url.origin !== location.origin) return;

--- a/app/templates/agents.html
+++ b/app/templates/agents.html
@@ -210,6 +210,7 @@ wikihub mcp-config                # prints mcpServers JSON pre-filled</pre></div
 
   <h2>Content negotiation</h2>
   <p><code>Accept: text/markdown</code> on any page URL returns raw markdown. Or append <code>.md</code>.</p>
+  <p>For rendered HTML without the full reader chrome, append <code>?fragment=1</code> to a page URL. The response is JSON with <code>title</code>, <code>html</code>, <code>url</code>, and <code>path</code>, and it uses the same ACL checks as the full page route.</p>
 
   <h2>Discovery</h2>
   <ul>

--- a/app/templates/reader.html
+++ b/app/templates/reader.html
@@ -164,6 +164,51 @@
   .reader-layout.right-collapsed .right-panel-reopen { display: inline-flex; }
 }
 
+/* Side peek (wikihub-9k18) — slide-over preview of an internal link */
+.peek-overlay {
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(0, 0, 0, 0.4);
+  opacity: 0; transition: opacity 0.18s ease;
+  display: flex; justify-content: flex-end;
+}
+.peek-overlay.open { opacity: 1; }
+.peek-overlay[hidden] { display: none; }
+.peek-panel {
+  width: 46vw; max-width: 820px; min-width: 380px;
+  height: 100%; background: var(--bg-base);
+  border-left: 1px solid var(--border-emphasis);
+  display: flex; flex-direction: column;
+  transform: translateX(24px); transition: transform 0.18s ease;
+  box-sizing: border-box;
+}
+.peek-overlay.open .peek-panel { transform: translateX(0); }
+.peek-head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 16px; border-bottom: 1px solid var(--border-default);
+  flex-shrink: 0;
+}
+.peek-title {
+  font-weight: 600; font-size: 0.9375rem; color: var(--text-primary);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1;
+}
+.peek-actions { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
+.peek-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px; border-radius: var(--radius-sm);
+  border: 1px solid transparent; background: transparent;
+  color: var(--text-tertiary); cursor: pointer; text-decoration: none;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.peek-btn:hover { background: var(--bg-surface); color: var(--text-primary); border-color: var(--border-default); }
+.peek-copy.copied { color: var(--accent); border-color: var(--border-accent); }
+.peek-body {
+  flex: 1; overflow-y: auto; padding: 24px 32px 60px;
+  max-width: none;
+}
+@media (max-width: 767px) {
+  .peek-panel { width: 100vw; min-width: 0; max-width: none; }
+}
+
 .breadcrumb {
   font-size: 0.8125rem; color: var(--text-muted); margin-bottom: 12px;
   font-family: var(--font-mono); display: flex; align-items: center; flex-wrap: wrap;
@@ -2076,4 +2121,7 @@ function revokeShare(username) {
 document.addEventListener('keydown', function(e) { if (e.key === 'Escape') closeShareModal(); });
 </script>
 {% endif %}
+
+<script>window.__wikihubPeek = { base: "/@{{ owner.username }}/{{ wiki.slug }}" };</script>
+<script src="{{ url_for('static', filename='js/sidepeek.js') }}"></script>
 {% endblock %}

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5374,6 +5374,30 @@ def test_side_peek_fragment_endpoint(client, api_key):
     assert data["url"] == "/@agent1/peek-wiki/wiki/target"
 
 
+def test_side_peek_fragment_endpoint_preserves_md_redirect(client, api_key):
+    """nsv-9wm: .md page links keep ?fragment=1 through the clean-URL redirect."""
+    h = {"Authorization": f"Bearer {api_key}"}
+    client.post("/api/v1/wikis", json={"slug": "peek-md", "title": "PeekMD"}, headers=h)
+    r = client.post("/api/v1/wikis/agent1/peek-md/pages", json={
+        "path": "wiki/target.md",
+        "content": "---\ntitle: Markdown Link Target\nvisibility: public\n---\n\n# Markdown Link Target\n\nBody **here**.",
+        "visibility": "public",
+    }, headers=h)
+    assert r.status_code == 201, r.get_json()
+
+    r = client.get("/@agent1/peek-md/wiki/target.md?fragment=1", follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["Location"].endswith("/@agent1/peek-md/wiki/target?fragment=1")
+
+    r = client.get("/@agent1/peek-md/wiki/target.md?fragment=1", follow_redirects=True)
+    assert r.status_code == 200, r.get_data(as_text=True)[:200]
+    assert "application/json" in r.content_type
+    data = r.get_json()
+    assert data["title"] == "Markdown Link Target"
+    assert "<strong>here</strong>" in data["html"]
+    assert data["url"] == "/@agent1/peek-md/wiki/target"
+
+
 def test_side_peek_fragment_respects_acl_for_anon(client, api_key):
     """wikihub-9k18: the fragment endpoint reuses the full page-route ACL, so a
     private page must NOT be readable via ?fragment=1 by an anonymous viewer."""
@@ -6007,6 +6031,7 @@ def run_all():
             ("visibility toggle resolves underscore filename (wikihub-vbug)", lambda: test_visibility_toggle_for_underscore_filename(client, key)),
             ("page lookup consistent across endpoints for underscore path (wikihub-wkmg+vbug)", lambda: test_page_lookup_consistent_across_endpoints_for_underscore_path(client, key)),
             ("side peek fragment endpoint (wikihub-9k18)", lambda: test_side_peek_fragment_endpoint(client, key)),
+            ("side peek .md fragment redirect (nsv-9wm)", lambda: test_side_peek_fragment_endpoint_preserves_md_redirect(client, key)),
             ("side peek fragment respects ACL for anon (wikihub-9k18)", lambda: test_side_peek_fragment_respects_acl_for_anon(client, key)),
             ("side peek preserves same-page anchors (nsv-7lr)", lambda: test_side_peek_preserves_same_page_anchor_clicks()),
             ("side peek scrolls peek self anchors (nsv-7ki)", lambda: test_side_peek_scrolls_peek_self_anchors()),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5495,7 +5495,7 @@ dispatch("/@agent1/peek-wiki/wiki/source#toc");
 
 
 def test_side_peek_scrolls_peek_self_anchors():
-    """nsv-7ki: peek self-anchors scroll inside the panel with escaped IDs."""
+    """nsv-7ki/nsv-oxc: peek links resolve and navigate inside the panel."""
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     script = r"""
 const fs = require("fs");
@@ -5509,6 +5509,9 @@ const vm = require("vm");
   let peekClickHandler = null;
   let domReadyHandler = null;
   let scrolledTo = [];
+  let fetchedUrls = [];
+  let pushedStates = [];
+  let replacedStates = [];
 
   const article = {
     addEventListener(type, fn) {
@@ -5594,9 +5597,21 @@ const vm = require("vm");
         if (type === "DOMContentLoaded") domReadyHandler = fn;
       }
     },
-    history: { state: null, pushState() {}, replaceState() {}, back() {} },
+    history: {
+      state: null,
+      pushState(state, _title, url) {
+        this.state = state;
+        pushedStates.push({ state, url });
+      },
+      replaceState(state, _title, url) {
+        this.state = state;
+        replacedStates.push({ state, url });
+      },
+      back() {}
+    },
     navigator: {},
     fetch() {
+      fetchedUrls.push(arguments[0]);
       return Promise.resolve({
         ok: true,
         headers: { get() { return "application/json"; } },
@@ -5604,12 +5619,12 @@ const vm = require("vm");
           return Promise.resolve({
             title: "Target",
             html: "<h2 id=\"h.foo\">H</h2><h2 id=\"2026\">Y</h2>",
-            url: "/@agent1/peek-wiki/wiki/target"
+            url: "/@agent1/peek-wiki/wiki/folder/target"
           });
         }
       });
     },
-    setTimeout() {}
+    setTimeout
   };
 
   vm.runInNewContext(source, context, { filename: sidepeekPath });
@@ -5647,7 +5662,7 @@ const vm = require("vm");
     return prevented;
   }
 
-  if (!dispatch(articleClickHandler, "/@agent1/peek-wiki/wiki/target#h.foo", false)) {
+  if (!dispatch(articleClickHandler, "/@agent1/peek-wiki/wiki/folder/target#h.foo", false)) {
     throw new Error("cross-page peek link was not intercepted");
   }
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -5655,12 +5670,29 @@ const vm = require("vm");
     throw new Error("peek did not scroll escaped load hash; got " + scrolledTo.join(","));
   }
   if (!peekClickHandler) throw new Error("peek click handler was not registered");
+  if (pushedStates.length !== 1) {
+    throw new Error("initial peek should push one history entry; got " + pushedStates.length);
+  }
 
-  if (!dispatch(peekClickHandler, "/@agent1/peek-wiki/wiki/target#2026", true)) {
+  if (!dispatch(peekClickHandler, "/@agent1/peek-wiki/wiki/folder/target#2026", true)) {
     throw new Error("peek self-anchor was not intercepted");
   }
   if (scrolledTo.join(",") !== "h.foo,2026") {
     throw new Error("peek self-anchor did not scroll inside panel; got " + scrolledTo.join(","));
+  }
+
+  if (!dispatch(peekClickHandler, "next", true)) {
+    throw new Error("peek relative link was not intercepted");
+  }
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  if (!fetchedUrls[1] || fetchedUrls[1].indexOf("/@agent1/peek-wiki/wiki/folder/next?fragment=1") < 0) {
+    throw new Error("peek relative link resolved to wrong fetch URL: " + fetchedUrls.join(","));
+  }
+  if (pushedStates.length !== 1) {
+    throw new Error("in-panel navigation pushed a new history entry");
+  }
+  if (replacedStates.length !== 1) {
+    throw new Error("in-panel navigation should replace history once; got " + replacedStates.length);
   }
 })().catch((err) => {
   console.error(err && err.stack ? err.stack : err);

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5349,6 +5349,53 @@ def test_set_wiki_limit_script_imports_from_repo_root():
     assert "ModuleNotFoundError" not in r.stderr
 
 
+def test_side_peek_fragment_endpoint(client, api_key):
+    """wikihub-9k18: ?fragment=1 returns the rendered article body as JSON so
+    the side-peek panel can show a same-wiki link without navigating away."""
+    h = {"Authorization": f"Bearer {api_key}"}
+    client.post("/api/v1/wikis", json={"slug": "peek-wiki", "title": "Peek"}, headers=h)
+    r = client.post("/api/v1/wikis/agent1/peek-wiki/pages", json={
+        "path": "wiki/target.md",
+        "content": "---\ntitle: Peek Target\nvisibility: public\n---\n\n# Peek Target\n\nBody **here**.",
+        "visibility": "public",
+    }, headers=h)
+    assert r.status_code == 201, r.get_json()
+
+    r = client.get("/@agent1/peek-wiki/wiki/target?fragment=1")
+    assert r.status_code == 200, r.get_data(as_text=True)[:200]
+    assert "application/json" in r.content_type
+    data = r.get_json()
+    assert data["title"] == "Peek Target"
+    assert "Body" in data["html"] and "<strong>here</strong>" in data["html"]
+    # Fragment must be body-only: no full-page chrome (nav/sidebar/reader shell).
+    assert "reader-layout" not in data["html"]
+    assert "<html" not in data["html"].lower()
+    # Canonical full-page URL is provided for "open as full page" / copy-link.
+    assert data["url"] == "/@agent1/peek-wiki/wiki/target"
+
+
+def test_side_peek_fragment_respects_acl_for_anon(client, api_key):
+    """wikihub-9k18: the fragment endpoint reuses the full page-route ACL, so a
+    private page must NOT be readable via ?fragment=1 by an anonymous viewer."""
+    h = {"Authorization": f"Bearer {api_key}"}
+    client.post("/api/v1/wikis", json={"slug": "peek-acl", "title": "PeekACL"}, headers=h)
+    r = client.post("/api/v1/wikis/agent1/peek-acl/pages", json={
+        "path": "secret/plan.md",
+        "content": "---\ntitle: Secret Plan\nvisibility: private\n---\n\n# Secret Plan\n\ntop secret",
+        "visibility": "private",
+    }, headers=h)
+    assert r.status_code == 201, r.get_json()
+
+    anon = client.application.test_client()
+    anon.get("/auth/logout", follow_redirects=False)
+    r = anon.get("/@agent1/peek-acl/secret/plan?fragment=1")
+    assert r.status_code in (401, 403, 404), (
+        f"private page leaked via fragment endpoint (got {r.status_code})"
+    )
+    body = r.get_data(as_text=True)
+    assert "top secret" not in body, "fragment endpoint leaked private content to anon"
+
+
 def run_all():
     app = setup()
 
@@ -5458,6 +5505,8 @@ def run_all():
             ("500 page has reference + retry link", lambda: test_500_page_has_reference_and_retry(app, client)),
             ("visibility toggle resolves underscore filename (wikihub-vbug)", lambda: test_visibility_toggle_for_underscore_filename(client, key)),
             ("page lookup consistent across endpoints for underscore path (wikihub-wkmg+vbug)", lambda: test_page_lookup_consistent_across_endpoints_for_underscore_path(client, key)),
+            ("side peek fragment endpoint (wikihub-9k18)", lambda: test_side_peek_fragment_endpoint(client, key)),
+            ("side peek fragment respects ACL for anon (wikihub-9k18)", lambda: test_side_peek_fragment_respects_acl_for_anon(client, key)),
             ("CLI end-to-end", lambda: test_cli(client)),
             ("per-user wiki limit + 429 (wikihub-20ct)", lambda: test_wiki_limit_effective_resolution_and_429(client, app)),
             ("set_wiki_limit imports from app root (wikihub-20ct)", lambda: test_set_wiki_limit_script_imports_from_repo_root()),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5708,6 +5708,195 @@ const vm = require("vm");
     assert r.returncode == 0, r.stderr or r.stdout
 
 
+def test_side_peek_ignores_stale_fetch_responses():
+    """nsv-7nv: older side-peek fetches must not overwrite newer clicks."""
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script = r"""
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+(async () => {
+  const sidepeekPath = path.join(process.cwd(), "app/static/js/sidepeek.js");
+  const source = fs.readFileSync(sidepeekPath, "utf8");
+  let articleClickHandler = null;
+  let domReadyHandler = null;
+  let renderedHtml = "";
+  const requests = [];
+  const pushedUrls = [];
+
+  const article = {
+    addEventListener(type, fn) {
+      if (type === "click") articleClickHandler = fn;
+    }
+  };
+
+  const bodyEl = {
+    scrollTop: 0,
+    classList: { add() {}, remove() {} },
+    addEventListener() {},
+    set innerHTML(value) { renderedHtml = value; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; }
+  };
+
+  const titleEl = { textContent: "" };
+  const noopEl = {
+    classList: { add() {}, remove() {} },
+    setAttribute() {},
+    removeAttribute() {},
+    addEventListener() {},
+    querySelector() { return noopEl; },
+    set href(_value) {}
+  };
+
+  const overlay = {
+    offsetWidth: 1,
+    classList: { add() {}, remove() {} },
+    setAttribute() {},
+    removeAttribute() {},
+    addEventListener() {},
+    querySelector(selector) {
+      if (selector === "#peek-body") return bodyEl;
+      if (selector === "#peek-title") return titleEl;
+      return noopEl;
+    },
+    set innerHTML(_html) {}
+  };
+
+  const location = {
+    href: "http://example.test/@agent1/peek-wiki/wiki/source",
+    origin: "http://example.test",
+    pathname: "/@agent1/peek-wiki/wiki/source",
+    search: ""
+  };
+
+  const context = {
+    URL,
+    URLSearchParams,
+    location,
+    window: {
+      __wikihubPeek: { base: "/@agent1/peek-wiki" },
+      innerWidth: 1024,
+      addEventListener() {},
+      location
+    },
+    document: {
+      body: {
+        appendChild() {},
+        classList: { add() {}, remove() {} }
+      },
+      createElement() { return overlay; },
+      querySelector(selector) {
+        return selector.indexOf(".article") >= 0 ? article : null;
+      },
+      addEventListener(type, fn) {
+        if (type === "DOMContentLoaded") domReadyHandler = fn;
+      }
+    },
+    history: {
+      state: null,
+      pushState(state, _title, url) {
+        this.state = state;
+        pushedUrls.push(url);
+      },
+      replaceState() {},
+      back() {}
+    },
+    navigator: {},
+    fetch(url) {
+      let resolveResponse;
+      const promise = new Promise((resolve) => { resolveResponse = resolve; });
+      requests.push({
+        url,
+        resolve(data) {
+          resolveResponse({
+            ok: true,
+            headers: { get() { return "application/json"; } },
+            json() { return Promise.resolve(data); }
+          });
+        }
+      });
+      return promise;
+    },
+    setTimeout
+  };
+
+  vm.runInNewContext(source, context, { filename: sidepeekPath });
+  domReadyHandler();
+
+  function makeAnchor(rawHref) {
+    return {
+      href: new URL(rawHref, location.href).href,
+      target: "",
+      classList: { contains() { return false; } },
+      hasAttribute() { return false; },
+      getAttribute(name) { return name === "href" ? rawHref : null; },
+      closest(selector) {
+        if (selector === "a") return this;
+        if (selector === ".article, .peek-body") return article;
+        if (selector === ".peek-body") return null;
+        return null;
+      }
+    };
+  }
+
+  function dispatch(rawHref) {
+    const anchor = makeAnchor(rawHref);
+    articleClickHandler({
+      defaultPrevented: false,
+      button: 0,
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: anchor,
+      preventDefault() {}
+    });
+  }
+
+  dispatch("/@agent1/peek-wiki/wiki/slow");
+  dispatch("/@agent1/peek-wiki/wiki/fast");
+  if (requests.length !== 2) {
+    throw new Error("expected two side-peek fetches, got " + requests.length);
+  }
+
+  requests[1].resolve({
+    title: "Fast",
+    html: "<p>fast</p>",
+    url: "/@agent1/peek-wiki/wiki/fast"
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  requests[0].resolve({
+    title: "Slow",
+    html: "<p>slow</p>",
+    url: "/@agent1/peek-wiki/wiki/slow"
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  if (renderedHtml !== "<p>fast</p>") {
+    throw new Error("stale fetch overwrote latest render: " + renderedHtml);
+  }
+  if (titleEl.textContent !== "Fast") {
+    throw new Error("stale fetch overwrote latest title: " + titleEl.textContent);
+  }
+  if (pushedUrls.length !== 1 || pushedUrls[0] !== "/@agent1/peek-wiki/wiki/source?peek=wiki%2Ffast") {
+    throw new Error("history was not updated only for latest fetch: " + pushedUrls.join(","));
+  }
+})().catch((err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});
+"""
+    r = subprocess.run(
+        ["node", "-e", script],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+    )
+    assert r.returncode == 0, r.stderr or r.stdout
+
+
 def run_all():
     app = setup()
 
@@ -5821,6 +6010,7 @@ def run_all():
             ("side peek fragment respects ACL for anon (wikihub-9k18)", lambda: test_side_peek_fragment_respects_acl_for_anon(client, key)),
             ("side peek preserves same-page anchors (nsv-7lr)", lambda: test_side_peek_preserves_same_page_anchor_clicks()),
             ("side peek scrolls peek self anchors (nsv-7ki)", lambda: test_side_peek_scrolls_peek_self_anchors()),
+            ("side peek ignores stale fetch responses (nsv-7nv)", lambda: test_side_peek_ignores_stale_fetch_responses()),
             ("CLI end-to-end", lambda: test_cli(client)),
             ("per-user wiki limit + 429 (wikihub-20ct)", lambda: test_wiki_limit_effective_resolution_and_429(client, app)),
             ("set_wiki_limit imports from app root (wikihub-20ct)", lambda: test_set_wiki_limit_script_imports_from_repo_root()),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5494,6 +5494,188 @@ dispatch("/@agent1/peek-wiki/wiki/source#toc");
     assert r.returncode == 0, r.stderr or r.stdout
 
 
+def test_side_peek_scrolls_peek_self_anchors():
+    """nsv-7ki: peek self-anchors scroll inside the panel with escaped IDs."""
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script = r"""
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+(async () => {
+  const sidepeekPath = path.join(process.cwd(), "app/static/js/sidepeek.js");
+  const source = fs.readFileSync(sidepeekPath, "utf8");
+  let articleClickHandler = null;
+  let peekClickHandler = null;
+  let domReadyHandler = null;
+  let scrolledTo = [];
+
+  const article = {
+    addEventListener(type, fn) {
+      if (type === "click") articleClickHandler = fn;
+    }
+  };
+
+  const targets = {
+    "h.foo": { id: "h.foo", scrollIntoView() { scrolledTo.push("h.foo"); } },
+    "2026": { id: "2026", scrollIntoView() { scrolledTo.push("2026"); } }
+  };
+
+  const bodyEl = {
+    scrollTop: 0,
+    classList: { add() {}, remove() {} },
+    addEventListener(type, fn) {
+      if (type === "click") peekClickHandler = fn;
+    },
+    set innerHTML(_html) {},
+    querySelector(selector) {
+      if (selector === "#escaped:h.foo") return targets["h.foo"];
+      if (selector === "#escaped:2026") return targets["2026"];
+      if (selector === "#h.foo" || selector === "#2026") {
+        throw new Error("raw hash selector used: " + selector);
+      }
+      return null;
+    },
+    querySelectorAll() {
+      return Object.values(targets);
+    }
+  };
+
+  const noopEl = {
+    classList: { add() {}, remove() {} },
+    setAttribute() {},
+    removeAttribute() {},
+    addEventListener() {},
+    querySelector() { return noopEl; },
+    set href(_value) {}
+  };
+
+  const overlay = {
+    offsetWidth: 1,
+    classList: { add() {}, remove() {} },
+    setAttribute() {},
+    removeAttribute() {},
+    addEventListener() {},
+    querySelector(selector) {
+      if (selector === "#peek-body") return bodyEl;
+      return noopEl;
+    },
+    set innerHTML(_html) {}
+  };
+
+  const location = {
+    href: "http://example.test/@agent1/peek-wiki/wiki/source",
+    origin: "http://example.test",
+    pathname: "/@agent1/peek-wiki/wiki/source",
+    search: ""
+  };
+
+  const context = {
+    URL,
+    URLSearchParams,
+    location,
+    window: {
+      __wikihubPeek: { base: "/@agent1/peek-wiki" },
+      innerWidth: 1024,
+      addEventListener() {},
+      location,
+      CSS: { escape(value) { return "escaped:" + value; } }
+    },
+    document: {
+      body: {
+        appendChild() {},
+        classList: { add() {}, remove() {} }
+      },
+      createElement() { return overlay; },
+      querySelector(selector) {
+        return selector.indexOf(".article") >= 0 ? article : null;
+      },
+      addEventListener(type, fn) {
+        if (type === "DOMContentLoaded") domReadyHandler = fn;
+      }
+    },
+    history: { state: null, pushState() {}, replaceState() {}, back() {} },
+    navigator: {},
+    fetch() {
+      return Promise.resolve({
+        ok: true,
+        headers: { get() { return "application/json"; } },
+        json() {
+          return Promise.resolve({
+            title: "Target",
+            html: "<h2 id=\"h.foo\">H</h2><h2 id=\"2026\">Y</h2>",
+            url: "/@agent1/peek-wiki/wiki/target"
+          });
+        }
+      });
+    },
+    setTimeout() {}
+  };
+
+  vm.runInNewContext(source, context, { filename: sidepeekPath });
+  domReadyHandler();
+
+  function makeAnchor(rawHref, inPeek) {
+    return {
+      href: new URL(rawHref, location.href).href,
+      target: "",
+      classList: { contains() { return false; } },
+      hasAttribute() { return false; },
+      getAttribute(name) { return name === "href" ? rawHref : null; },
+      closest(selector) {
+        if (selector === "a") return this;
+        if (selector === ".article, .peek-body") return inPeek ? bodyEl : article;
+        if (selector === ".peek-body") return inPeek ? bodyEl : null;
+        return null;
+      }
+    };
+  }
+
+  function dispatch(handler, rawHref, inPeek) {
+    let prevented = false;
+    const anchor = makeAnchor(rawHref, inPeek);
+    handler({
+      defaultPrevented: false,
+      button: 0,
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      target: anchor,
+      preventDefault() { prevented = true; }
+    });
+    return prevented;
+  }
+
+  if (!dispatch(articleClickHandler, "/@agent1/peek-wiki/wiki/target#h.foo", false)) {
+    throw new Error("cross-page peek link was not intercepted");
+  }
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  if (scrolledTo.join(",") !== "h.foo") {
+    throw new Error("peek did not scroll escaped load hash; got " + scrolledTo.join(","));
+  }
+  if (!peekClickHandler) throw new Error("peek click handler was not registered");
+
+  if (!dispatch(peekClickHandler, "/@agent1/peek-wiki/wiki/target#2026", true)) {
+    throw new Error("peek self-anchor was not intercepted");
+  }
+  if (scrolledTo.join(",") !== "h.foo,2026") {
+    throw new Error("peek self-anchor did not scroll inside panel; got " + scrolledTo.join(","));
+  }
+})().catch((err) => {
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+});
+"""
+    r = subprocess.run(
+        ["node", "-e", script],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+    )
+    assert r.returncode == 0, r.stderr or r.stdout
+
+
 def run_all():
     app = setup()
 
@@ -5606,6 +5788,7 @@ def run_all():
             ("side peek fragment endpoint (wikihub-9k18)", lambda: test_side_peek_fragment_endpoint(client, key)),
             ("side peek fragment respects ACL for anon (wikihub-9k18)", lambda: test_side_peek_fragment_respects_acl_for_anon(client, key)),
             ("side peek preserves same-page anchors (nsv-7lr)", lambda: test_side_peek_preserves_same_page_anchor_clicks()),
+            ("side peek scrolls peek self anchors (nsv-7ki)", lambda: test_side_peek_scrolls_peek_self_anchors()),
             ("CLI end-to-end", lambda: test_cli(client)),
             ("per-user wiki limit + 429 (wikihub-20ct)", lambda: test_wiki_limit_effective_resolution_and_429(client, app)),
             ("set_wiki_limit imports from app root (wikihub-20ct)", lambda: test_set_wiki_limit_script_imports_from_repo_root()),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5396,6 +5396,104 @@ def test_side_peek_fragment_respects_acl_for_anon(client, api_key):
     assert "top secret" not in body, "fragment endpoint leaked private content to anon"
 
 
+def test_side_peek_preserves_same_page_anchor_clicks():
+    """nsv-7lr: in-page anchors should keep the browser's native scroll behavior."""
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script = r"""
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const sidepeekPath = path.join(process.cwd(), "app/static/js/sidepeek.js");
+const source = fs.readFileSync(sidepeekPath, "utf8");
+let articleClickHandler = null;
+let domReadyHandler = null;
+
+const article = {
+  addEventListener(type, fn) {
+    if (type === "click") articleClickHandler = fn;
+  }
+};
+
+const location = {
+  href: "http://example.test/@agent1/peek-wiki/wiki/source",
+  origin: "http://example.test",
+  pathname: "/@agent1/peek-wiki/wiki/source",
+  search: ""
+};
+
+const context = {
+  URL,
+  URLSearchParams,
+  location,
+  window: {
+    __wikihubPeek: { base: "/@agent1/peek-wiki" },
+    innerWidth: 1024,
+    addEventListener() {},
+    location
+  },
+  document: {
+    body: { appendChild() {}, classList: { add() {}, remove() {} } },
+    querySelector(selector) {
+      return selector.indexOf(".article") >= 0 ? article : null;
+    },
+    addEventListener(type, fn) {
+      if (type === "DOMContentLoaded") domReadyHandler = fn;
+    }
+  },
+  history: { state: null, pushState() {}, replaceState() {}, back() {} },
+  navigator: {},
+  setTimeout() {}
+};
+
+vm.runInNewContext(source, context, { filename: sidepeekPath });
+if (!domReadyHandler) throw new Error("DOMContentLoaded handler was not registered");
+domReadyHandler();
+if (!articleClickHandler) throw new Error("article click handler was not registered");
+
+function makeAnchor(rawHref) {
+  return {
+    href: new URL(rawHref, location.href).href,
+    target: "",
+    classList: { contains() { return false; } },
+    hasAttribute() { return false; },
+    getAttribute(name) { return name === "href" ? rawHref : null; },
+    closest(selector) {
+      if (selector === "a") return this;
+      if (selector === ".article, .peek-body") return article;
+      return null;
+    }
+  };
+}
+
+function dispatch(rawHref) {
+  let prevented = false;
+  const anchor = makeAnchor(rawHref);
+  articleClickHandler({
+    defaultPrevented: false,
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    target: anchor,
+    preventDefault() { prevented = true; }
+  });
+  if (prevented) throw new Error(rawHref + " was intercepted");
+}
+
+dispatch("#footnote-1");
+dispatch("/@agent1/peek-wiki/wiki/source#toc");
+"""
+    r = subprocess.run(
+        ["node", "-e", script],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+    )
+    assert r.returncode == 0, r.stderr or r.stdout
+
+
 def run_all():
     app = setup()
 
@@ -5507,6 +5605,7 @@ def run_all():
             ("page lookup consistent across endpoints for underscore path (wikihub-wkmg+vbug)", lambda: test_page_lookup_consistent_across_endpoints_for_underscore_path(client, key)),
             ("side peek fragment endpoint (wikihub-9k18)", lambda: test_side_peek_fragment_endpoint(client, key)),
             ("side peek fragment respects ACL for anon (wikihub-9k18)", lambda: test_side_peek_fragment_respects_acl_for_anon(client, key)),
+            ("side peek preserves same-page anchors (nsv-7lr)", lambda: test_side_peek_preserves_same_page_anchor_clicks()),
             ("CLI end-to-end", lambda: test_cli(client)),
             ("per-user wiki limit + 429 (wikihub-20ct)", lambda: test_wiki_limit_effective_resolution_and_429(client, app)),
             ("set_wiki_limit imports from app root (wikihub-20ct)", lambda: test_set_wiki_limit_script_imports_from_repo_root()),


### PR DESCRIPTION
## Notion-style side peek for internal wiki links (wikihub-9k18)

Clicking an internal same-wiki page link opens the target page in a right-side slide-over panel instead of navigating away, so readers keep their place while working through a compiled wiki (e.g. a directory index with lots of link-hopping).

### Feature
- **Interaction:** normal click on a same-wiki page link peeks; modified clicks (cmd/ctrl/shift/alt/middle), external links, broken wikilinks, and mobile (≤767px) keep default full-page navigation. Links inside the peek navigate within the peek — one level only, no stacking.
- **Controls:** close (X / Esc / click-outside), open-as-full-page, copy-link.
- **Deep-linkable:** `?peek=<page-path>` restores the peek on load and is shareable; history-integrated so the browser back button closes it.
- **UI:** right slide-over (~46vw desktop, full-width mobile) using existing design-system tokens. No framework added — vanilla JS (`app/static/js/sidepeek.js`).

### Fragment endpoint + ACL
- New `?fragment=1` mode on the existing `wiki_page` route returns the server-rendered article body as JSON (`{title, html, url, path}`), reusing the one renderer + placed **after** all existing visibility/ACL checks — so a private page 404s in the fragment route for anon exactly as the full page does (no client-side render duplication, no private-content leak).
- Two e2e regression tests: fragment returns body-only JSON, and the fragment route returns 4xx (no content) for a private page requested anonymously.

### Fixes applied during no-mistakes review (edge cases the first pass missed)
1. **Same-page anchors** — footnote/TOC `#anchor` links are no longer hijacked into a peek; they scroll normally.
2. **In-peek anchor scrolling** — hash links inside the panel scroll within the panel, using `CSS.escape` so IDs starting with digits or containing dots don't throw.
3. **In-peek relative-link base** — relative links inside the peek resolve against the peeked page's URL, not the underlying reader page.
4. **Close always closes** — in-peek navigation uses `replaceState` (not `pushState`), so Esc/X/click-outside/back dismiss the whole peek rather than stepping back through visited pages.
5. **Stale-fetch race guard** — a request sequence counter prevents a slower older response from overwriting a newer peek.
6. **`.md`-suffixed links** — `?fragment=1` is preserved through the `.md`→clean-URL redirect so explicit `.md` links stay peekable.

### Validation
Validated through the no-mistakes pipeline (review + test + lint green), including live browser verification of open/close/deep-link with screenshots. Rebased onto latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
