### PR TITLE
feat(app): add reader live update indicator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ tests are intentional — each one verifies a real user flow end-to-end or a bro
 5. **zip upload** — create wiki via web form with zip file
 6. **agent surfaces** — all discovery endpoints respond (llms.txt, AGENTS.md, .well-known/*)
 7. **ACL permissions** — private pages not readable without auth
-8. **reader behavior** — sidebar, page controls, side peek, and other browser-facing regressions
+8. **reader behavior** — sidebar, page controls, side peek, live updates, and other browser-facing regressions
 
 don't add unit tests for individual functions. if something breaks, add an e2e test that covers the broken flow. tests should run in <10 seconds.
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,19 @@ Authorization: Bearer wh_...
 POST /api/v1/wikis/myagent/research/pages
 Authorization: Bearer wh_...
 {"path": "wiki/hello.md", "content": "# Hello\n\nContent.", "visibility": "public"}
+
+GET /api/v1/wikis/myagent/research/pages/wiki/hello.md?meta=1
+Authorization: Bearer wh_...
+
+-> {"path": "wiki/hello.md", "content_hash": "...", "updated_at": "..."}
 ```
 
 Content negotiation: `Accept: text/markdown` on any page URL returns raw markdown. Or append `.md`.
 For the desktop reader side peek, append `?fragment=1` to a rendered page URL to get JSON
 `{title, html, url, path}` for the article body only; the route uses the same page ACL checks.
+Use `?meta=1` on the page-read API when a client only needs the latest
+`content_hash` and `updated_at` for lightweight change polling; it enforces the
+same read permissions as a full page read and does not return page content.
 
 Full docs at `/agents` when running.
 
@@ -122,7 +130,7 @@ source .venv/bin/activate && python3 tests/test_e2e.py
 ```
 
 End-to-end tests cover account creation, wiki lifecycle, search, social, upload,
-agent surfaces, ACL permissions, reader behavior, and regression cases.
+agent surfaces, ACL permissions, reader behavior, live-update polling, and regression cases.
 
 ## Architecture
 

--- a/app/routes/agent_surfaces.py
+++ b/app/routes/agent_surfaces.py
@@ -311,6 +311,25 @@ Content-Type: application/json
 {"path": "wiki/hello.md", "content": "# Hello\\n\\nContent.", "visibility": "public"}
 ```
 
+## poll page metadata
+
+when a client only needs to know whether a readable page changed, use the
+lightweight metadata form of the page-read endpoint:
+
+```
+GET /api/v1/wikis/your-name/my-wiki/pages/wiki/hello.md?meta=1
+Authorization: Bearer wh_...
+```
+
+response:
+
+```json
+{"path": "wiki/hello.md", "content_hash": "...", "updated_at": "..."}
+```
+
+the response omits page content and enforces the same read permissions as a full
+page read.
+
 ## git clone & push
 
 every wiki is a real git repo. use your API key as the password:

--- a/app/routes/api_wikis.py
+++ b/app/routes/api_wikis.py
@@ -640,6 +640,23 @@ def read_page(owner, slug, page_path):
         if not can_read(page.path, acl_rules, user.username if user else None, page.visibility):
             return {"error": "not_found", "message": "Page not found"}, 404
 
+    # Lightweight liveness poll (reader "page updated" indicator, wikihub live-reload).
+    # Returns only the content_hash + updated_at without reading the file from the
+    # repo — the cheapest surface that lets a viewer detect fresh content. ACL has
+    # already been enforced above, so this leaks nothing a full read wouldn't.
+    # Distinct param name from the sidepeek `?fragment=1` JSON endpoint to avoid
+    # conflicting once that branch lands.
+    if request.args.get("meta") == "1":
+        resp = jsonify({
+            "path": page.path,
+            "content_hash": page.content_hash,
+            "updated_at": page.updated_at.isoformat(),
+        })
+        if page.content_hash:
+            resp.headers["ETag"] = f'"{page.content_hash}"'
+        resp.headers["Cache-Control"] = "no-store"
+        return resp
+
     use_public_repo = not is_owner and page.visibility != "private"
     content = read_file_from_repo(owner_user.username, wiki.slug, page.path, public=use_public_repo)
     if content is None and page.visibility == "private" and user:

--- a/app/templates/agents.html
+++ b/app/templates/agents.html
@@ -124,6 +124,11 @@ curl -X POST {{ request.host_url }}api/v1/auth/magic-link \
   -H 'Content-Type: application/json' \
   -d '{"path":"wiki/hello.md","content":"# Hello\n\nMy first page.","visibility":"public"}'</pre></div>
 
+  <h2>Poll page metadata</h2>
+  <div class="code-block"><pre>curl -X GET {{ request.host_url }}api/v1/wikis/myagent/research/pages/wiki/hello.md?meta=1 \
+  -H 'Authorization: Bearer wh_...'</pre></div>
+  <p>Use <code>?meta=1</code> when a client only needs <code>content_hash</code> and <code>updated_at</code> to detect that a readable page changed. The response omits page content and uses the same read permissions as a full page read.</p>
+
   <h2>Plain English instructions</h2>
   <p>Paste this into Claude, ChatGPT, or any LLM assistant:</p>
   <div class="code-block"><pre>Step 1: Create an account by POSTing to {{ request.host_url }}api/v1/accounts

--- a/app/templates/reader.html
+++ b/app/templates/reader.html
@@ -2124,4 +2124,115 @@ document.addEventListener('keydown', function(e) { if (e.key === 'Escape') close
 
 <script>window.__wikihubPeek = { base: "/@{{ owner.username }}/{{ wiki.slug }}" };</script>
 <script src="{{ url_for('static', filename='js/sidepeek.js') }}"></script>
+
+{# Live "page updated" indicator (wikihub live-reload). Polls the lightweight
+   ?meta=1 endpoint while the tab is visible; shows a non-modal pill when the
+   page's content_hash changes so a viewer watching a bot-maintained page knows
+   fresh content exists. Polling only — no websockets/SSE. ACL is enforced
+   server-side, so anonymous viewers of unlisted/public pages work too. #}
+<style>
+#page-update-pill {
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%) translateY(12px);
+  z-index: 400;
+  display: none;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  background: var(--bg-elevated, #221f1b);
+  border: 1px solid var(--border-accent, rgba(212, 160, 74, 0.4));
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  color: var(--text-primary, #e8e2d8);
+  opacity: 0;
+  transition: opacity .2s ease, transform .2s ease;
+}
+#page-update-pill.open { display: flex; opacity: 1; transform: translateX(-50%) translateY(0); }
+#page-update-pill button {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font: inherit;
+  font-weight: 600;
+  background: var(--accent, #d4a04a);
+  color: #1a1712;
+}
+#page-update-pill button:hover { background: var(--accent-hover, #e0b35a); }
+#page-update-pill .pill-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent, #d4a04a);
+  flex: none;
+}
+</style>
+<div id="page-update-pill" role="status" aria-live="polite">
+  <span class="pill-dot" aria-hidden="true"></span>
+  <span>Page updated</span>
+  <button type="button" onclick="location.reload()">Reload</button>
+</div>
+<script>
+(function () {
+  var baseHash = {{ (page.content_hash or '') | tojson }};
+  if (!baseHash) return; // nothing to compare against
+
+  var pathSegments = {{ page.path | tojson }}.split('/').map(encodeURIComponent).join('/');
+  var metaUrl = '/api/v1/wikis/' + encodeURIComponent({{ owner.username | tojson }})
+    + '/' + encodeURIComponent({{ wiki.slug | tojson }})
+    + '/pages/' + pathSegments + '?meta=1';
+
+  var pill = document.getElementById('page-update-pill');
+  var stopped = false;              // pill shown or hard-stopped: stop polling
+  var timer = null;
+  var lastInteraction = Date.now();
+  var IDLE_LIMIT_MS = 30 * 60 * 1000; // pause after ~30min of no interaction
+
+  function nextDelay() {
+    // 20–30s with jitter
+    return 20000 + Math.floor(Math.random() * 10000);
+  }
+
+  function schedule() {
+    if (stopped) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(poll, nextDelay());
+  }
+
+  function showPill() {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    pill.classList.add('open');
+  }
+
+  function poll() {
+    if (stopped) return;
+    if (document.hidden) { schedule(); return; }              // pause while hidden
+    if (Date.now() - lastInteraction > IDLE_LIMIT_MS) { schedule(); return; } // pause when idle
+    fetch(metaUrl, { headers: { 'Accept': 'application/json' }, credentials: 'same-origin' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (data && data.content_hash && data.content_hash !== baseHash) {
+          showPill();
+        } else {
+          schedule();
+        }
+      })
+      .catch(function () { schedule(); }); // network hiccup: never blocks, just retries
+  }
+
+  ['mousemove', 'keydown', 'scroll', 'touchstart'].forEach(function (evt) {
+    window.addEventListener(evt, function () { lastInteraction = Date.now(); }, { passive: true });
+  });
+
+  document.addEventListener('visibilitychange', function () {
+    if (!document.hidden && !stopped) {
+      lastInteraction = Date.now();
+      poll(); // check immediately on returning to the tab
+    }
+  });
+
+  schedule();
+})();
+</script>
 {% endblock %}

--- a/docs/MCP_CONNECTOR_BLUEPRINT.md
+++ b/docs/MCP_CONNECTOR_BLUEPRINT.md
@@ -32,7 +32,7 @@
 | DELETE | `/api/v1/wikis/<owner>/<slug>` | Required (owner) |
 | POST | `/api/v1/wikis/<owner>/<slug>/pages` | Required |
 | GET | `/api/v1/wikis/<owner>/<slug>/pages` | Optional |
-| GET | `/api/v1/wikis/<owner>/<slug>/pages/<path>` | Optional |
+| GET | `/api/v1/wikis/<owner>/<slug>/pages/<path>` | Optional; `?meta=1` returns only `path`, `content_hash`, and `updated_at` for lightweight change polling after the same read ACL check |
 | PATCH | `/api/v1/wikis/<owner>/<slug>/pages/<path>` | Required |
 | DELETE | `/api/v1/wikis/<owner>/<slug>/pages/<path>` | Required |
 | POST | `/api/v1/wikis/<owner>/<slug>/pages/<path>/append-section` | Required |

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5921,6 +5921,78 @@ const vm = require("vm");
     assert r.returncode == 0, r.stderr or r.stdout
 
 
+def test_page_meta_liveness_endpoint(client, api_key):
+    """Live-reload indicator: GET ?meta=1 returns content_hash for cheap polling,
+    updates the hash when content changes, and enforces the same ACL as a full read
+    (no leak to anon on private pages)."""
+    from flask_login import logout_user
+    app = client.application
+    h = {"Authorization": f"Bearer {api_key}"}
+    r = client.post("/api/v1/wikis", json={"slug": "live-mix", "title": "Live"}, headers=h)
+    assert r.status_code == 201
+
+    # A public page + a private page.
+    r = client.post("/api/v1/wikis/agent1/live-mix/pages", json={
+        "path": "note.md",
+        "content": "# Note\n\nv1",
+        "visibility": "public",
+    }, headers=h)
+    assert r.status_code == 201
+    r = client.post("/api/v1/wikis/agent1/live-mix/pages", json={
+        "path": "secret.md",
+        "content": "# Secret\n\nhidden",
+        "visibility": "private",
+    }, headers=h)
+    assert r.status_code == 201
+
+    meta_url = "/api/v1/wikis/agent1/live-mix/pages/note.md?meta=1"
+
+    # meta=1 returns hash but NOT the body content.
+    r = client.get(meta_url, headers=h)
+    assert r.status_code == 200, f"meta poll got {r.status_code}"
+    data = r.get_json()
+    assert data.get("content_hash"), "meta response missing content_hash"
+    assert "content" not in data, "meta response must not include full content"
+    first_hash = data["content_hash"]
+    assert r.headers.get("ETag") == f'"{first_hash}"'
+
+    # After an edit, the hash changes — this is what the reader poll detects.
+    r = client.put("/api/v1/wikis/agent1/live-mix/pages/note.md", json={
+        "content": "# Note\n\nv2 updated",
+    }, headers=h)
+    assert r.status_code == 200
+    r = client.get(meta_url, headers=h)
+    assert r.status_code == 200
+    assert r.get_json()["content_hash"] != first_hash, "hash must change after edit"
+
+    # ACL: anon must NOT be able to poll a private page's hash.
+    with app.test_request_context():
+        logout_user()
+    anon = app.test_client()
+    r = anon.get("/api/v1/wikis/agent1/live-mix/pages/secret.md?meta=1")
+    assert r.status_code == 404, f"anon meta poll on private page leaked ({r.status_code})"
+    assert "content_hash" not in (r.get_json() or {}), "meta leaked private hash to anon"
+
+    # But anon CAN poll a public page (the KB / unlisted use case).
+    r = anon.get(meta_url)
+    assert r.status_code == 200, f"anon meta poll on public page got {r.status_code}"
+    assert r.get_json().get("content_hash"), "anon missing hash on public page"
+
+
+def test_reader_has_live_update_indicator(client, api_key):
+    """The reader page must ship the polling script + non-modal update pill."""
+    h = {"Authorization": f"Bearer {api_key}"}
+    client.post("/api/v1/wikis", json={"slug": "live-ui", "title": "Live UI"}, headers=h)
+    client.post("/api/v1/wikis/agent1/live-ui/pages", json={
+        "path": "watch.md", "content": "# Watch\n\nbody", "visibility": "public",
+    }, headers=h)
+    r = client.get("/@agent1/live-ui/watch")
+    assert r.status_code == 200
+    body = r.data.decode("utf-8", errors="replace")
+    assert 'id="page-update-pill"' in body, "reader missing update pill element"
+    assert "?meta=1" in body, "reader missing meta liveness poll"
+
+
 def run_all():
     app = setup()
 
@@ -6026,6 +6098,8 @@ def run_all():
             ("commit diff renders with async sidebar (wikihub-8vwd)", lambda: test_commit_diff_renders_when_sidebar_is_async(client, key)),
             ("graph filters private pages for anon (wikihub-8888.2)", lambda: test_graph_route_filters_private_pages_for_anon(client, key)),
             ("tag index filters private pages for anon (wikihub-8888.3)", lambda: test_tag_index_filters_private_pages_for_anon(client, key)),
+            ("page meta liveness endpoint (live-reload)", lambda: test_page_meta_liveness_endpoint(client, key)),
+            ("reader has live update indicator (live-reload)", lambda: test_reader_has_live_update_indicator(client, key)),
             ("owner renders deep nested page (proposals-grant regression)", lambda: test_owner_can_render_deep_nested_page_no_500(client, key)),
             ("500 page has reference + retry link", lambda: test_500_page_has_reference_and_retry(app, client)),
             ("visibility toggle resolves underscore filename (wikihub-vbug)", lambda: test_visibility_toggle_for_underscore_filename(client, key)),


### PR DESCRIPTION
## Intent

Add a reader-side live 'page updated' indicator to WikiHub so someone watching a page (e.g. a bot-maintained knowledge base growing in real time) knows fresh content exists without manually reloading. Reuse the editor's existing detection mechanism (poll a read endpoint, compare content_hash) rather than inventing a new one. Decisions/tradeoffs: (1) Added a lightweight GET .../pages/<path>?meta=1 short-circuit returning only content_hash+updated_at with no repo file read, after the SAME ACL check as a normal read, so anonymous viewers of public/unlisted pages work and nothing leaks about private pages (anon gets 404). Chose ?meta=1 deliberately distinct from an unmerged sidepeek branch's ?fragment=1 to avoid a future conflict. (2) reader.html polls every 20-30s with jitter, only while the tab is VISIBLE (visibilitychange), pausing when hidden and after ~30min idle to avoid infinite background polling. On a content_hash change it shows a small non-modal bottom-center 'Page updated / Reload' pill styled from the design tokens; one click calls location.reload(). Polling only, no websockets/SSE by design. (3) Tests: endpoint-level (hash surface present, body content absent, hash changes after edit, anon blocked on private, anon allowed on public) plus a reader-template test that the poll+pill ship. All 91 e2e pass; verified in-browser. Out of scope: push/SSE infra, in-place content morphing, editor changes, notification emails.

## What Changed

- Added a lightweight page metadata read path that returns `content_hash` and `updated_at` after the normal ACL check, without including page body content.
- Added reader-side polling that watches for content hash changes while the tab is visible and shows a non-modal "Page updated" reload pill when newer content is available.
- Updated agent-facing docs and e2e coverage for metadata polling, private/public access behavior, and the reader update indicator.

## Risk Assessment

✅ Low: The change is narrowly scoped to a read-only metadata endpoint, a reader-side polling indicator, and focused e2e coverage, with ACL checks reused before exposing the new hash surface.

## Testing

After resolving local setup issues with a throwaway in-worktree venv and isolated Postgres on port 7543, the full e2e suite passed, then browser verification showed the reader page detecting a changed `content_hash`, displaying the `Page updated / Reload` pill, and reloading to the updated page content; screenshots and the meta-poll transcript were saved as evidence.

- Evidence: Reader before update (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXPMEMZQCKJ8MFE1ACGC0H08/reader-before-update.png</code>)
- Evidence: Reader update pill visible (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXPMEMZQCKJ8MFE1ACGC0H08/reader-update-pill-clean.png</code>)
- Evidence: Reader after Reload shows updated content (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXPMEMZQCKJ8MFE1ACGC0H08/reader-after-reload.png</code>)
<details>
<summary>Evidence: Meta poll before/after content_hash transcript</summary>

```text
Before update meta:
{"content_hash":"7ca6b6ed5542fba968afb552b145ae1292346d079424cdd9b6234ede6fffb04b","path":"watch.md","updated_at":"2026-07-16T16:42:18.448387-07:00"}


Update response:
{"id":10,"path":"watch.md","title":"watch","visibility":"public"}


After update meta:
{"content_hash":"f591242dd7b99b4b43ac8398332e7302c219a7e3048d7430d60c0b59e01f03c4","path":"watch.md","updated_at":"2026-07-16T16:42:38.888567-07:00"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/test_e2e.py` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`source .venv/bin/activate &amp;&amp; python3 tests/test_e2e.py` (documented setup unavailable: `.venv` missing)</code>
- <code>`python3 -c &#34;import flask, sqlalchemy, markdown_it&#34;` (system Python missing project deps)</code>
- `python3.11 -m venv .venv && .venv/bin/python -m pip install -r requirements.txt`
- <code>`.venv/bin/python tests/test_e2e.py` (default Postgres.app auth blocked; fixed by starting isolated test Postgres)</code>
- <code>`initdb -D .tmp-pg --auth=trust --no-locale --encoding=UTF8` and `pg_ctl -D .tmp-pg -l .tmp-pg.log -o &#34;-p 7543 -h 127.0.0.1&#34; start &amp;&amp; PGPORT=7543 createdb -h 127.0.0.1 wikihub_test`</code>
- `PGPORT=7543 .venv/bin/python tests/test_e2e.py`
- `PGPORT=7543 SECRET_KEY=dev DATABASE_URL=postgresql://localhost/wikihub_test REPOS_DIR=./.tmp-live-repos ADMIN_TOKEN=devtoken SESSION_COOKIE_SECURE=0 .venv/bin/flask --app wsgi.py run --port 8765`
- <code>`curl` API setup: create account, create `live-demo`, create public `watch.md`</code>
- `chrome-devtools-axi open http://127.0.0.1:8765/@livecheck1784245336/live-demo/watch && chrome-devtools-axi screenshot .../reader-before-update.png`
- <code>`curl` meta-poll before/after plus `PUT /api/v1/wikis/livecheck1784245336/live-demo/pages/watch.md`</code>
- `chrome-devtools-axi eval "() => { document.dispatchEvent(new Event('visibilitychange')); ... }" && chrome-devtools-axi eval "() => ({ pillClass, pillDisplay, pillOpacity, pillText })" && chrome-devtools-axi screenshot .../reader-update-pill-clean.png`
- `chrome-devtools-axi click @g190:244_2 && chrome-devtools-axi eval "() => document.body.innerText.includes('Updated content that should trigger the live page-updated indicator.')" && chrome-devtools-axi screenshot .../reader-after-reload.png`
- <code>Stopped Flask and Postgres, removed transient `.venv`, `.tmp-pg*`, `.tmp-live-repos`, and `/tmp/wikihub-test-repos`; `git status --short` was clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
