### PR TITLE
fix(wiki): show unlisted pages in in-wiki navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ host (`ubuntu@54.145.123.7`) — that's historical. Production is GCP now.
 - **DB→git sync does NOT fire hooks.** this prevents infinite sync loops.
 - **two repos per wiki:** `repos/<user>/<slug>.git` (authoritative) + `repos/<user>/<slug>-public.git` (derived mirror).
 - **frontmatter visibility wins over ACL file** (most specific wins).
+- **unlisted is readable-by-URL but not discoverable.** Link-holders who can read an unlisted page see it inside the wiki's own sidebar/page tree; search, explore, and profile listings still exclude it.
 - **API keys start with `wh_`**, SHA-256 hashed in DB, shown once on creation.
 - **wiki caps resolve per user.** `User.wiki_limit` overrides `MAX_WIKIS_PER_USER`; enforcement and `/api/v1/me/capabilities` must use `User.effective_wiki_limit()`.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Full docs at `/agents` when running.
 Page `visibility` values are `public`, `public-edit`, `private`, `unlisted`,
 and `unlisted-edit`. When visibility is inherited from `.wikihub/acl`,
 ACL-only `public-view` and `unlisted-view` directives are reported as
-`public` and `unlisted` on the page.
+`public` and `unlisted` on the page. Unlisted pages are readable by direct
+URL and appear in that wiki's own navigation/sidebar for viewers who can read
+them, but stay out of discovery surfaces such as search, explore, and profiles.
 
 `max_wikis_per_user` is the authenticated account's effective wiki cap: the
 server default unless a per-user override is set. Wiki create and fork requests
@@ -112,7 +114,9 @@ ACL visibility directives are `private`, `public-view`, `public-edit`,
 `unlisted-view`, and `unlisted-edit`; the shorter `public` and `unlisted`
 forms are accepted as aliases. Frontmatter `visibility:` on individual files
 overrides the ACL and is stored as the page-level enum: `public`, `public-edit`,
-`private`, `unlisted`, or `unlisted-edit`.
+`private`, `unlisted`, or `unlisted-edit`. Unlisted governs discovery, not
+in-wiki navigation: a link-holder who can read the page sees it in the wiki
+sidebar, while search/explore/profile listings still exclude it.
 
 ## Feedback
 

--- a/app/acl.py
+++ b/app/acl.py
@@ -223,7 +223,11 @@ def can_write(path, rules, user=None, frontmatter_visibility=None):
 
 
 def is_discoverable(path, rules, frontmatter_visibility=None):
-    """check if a file appears in listings/search."""
+    """check if a file appears in discovery surfaces such as listings/search.
+
+    Unlisted pages intentionally return False here even though can_read() allows
+    anonymous direct-link access; in-wiki navigation should use can_read().
+    """
     vis = normalize_visibility(resolve_visibility(path, rules, frontmatter_visibility))
     return vis in ("public-view", "public-edit")
 

--- a/app/routes/agent_surfaces.py
+++ b/app/routes/agent_surfaces.py
@@ -314,7 +314,9 @@ Content-Type: application/json
 Page `visibility` values are `public`, `public-edit`, `private`, `unlisted`,
 and `unlisted-edit`. If omitted, the page inherits from `.wikihub/acl`; ACL-only
 `public-view` and `unlisted-view` directives are stored and reported as
-`public` and `unlisted` page visibility.
+`public` and `unlisted` page visibility. Unlisted pages are readable by direct
+URL and appear in that wiki's own navigation/sidebar for viewers who can read
+them, but stay out of discovery surfaces such as search, explore, and profiles.
 
 ## poll page metadata
 

--- a/app/routes/wiki.py
+++ b/app/routes/wiki.py
@@ -333,19 +333,21 @@ def _visible_files(username, slug, wiki, public=False, acl_filter_user=None, pag
             and can_read(path, acl_rules, acl_filter_user, (pages_by_path[path].visibility if path in pages_by_path else None))
         ]
 
+    # Anonymous / public-mirror viewer. The sidebar is in-wiki navigation, not a
+    # discovery surface: 'unlisted' governs search/explore/profile listings, but a
+    # viewer who already possesses the wiki link and can_read a page must see it in
+    # the wiki's own page tree (wikihub #17). Gate on can_read (which admits public,
+    # public-edit, and unlisted), NOT is_discoverable. The public mirror already
+    # excludes private pages, so files here are readable-by-URL by construction.
+    acl_rules = load_acl_rules(username, slug)
     if pages_by_path is None:
         pages_by_path = {p.path: p for p in Page.query.filter_by(wiki_id=wiki.id).all()}
-    discoverable = {
-        path
-        for path, page in pages_by_path.items()
-        if page.visibility in ("public", "public-view", "public-edit")
-    }
     return [
         path
         for path in files
         if not path.startswith(".wikihub/")
         and not path.endswith(".gitkeep")
-        and path in discoverable
+        and can_read(path, acl_rules, None, (pages_by_path[path].visibility if path in pages_by_path else None))
     ]
 
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -60,7 +60,9 @@ wikihub search "hello" --wiki you/notes
 `write` and `publish` accept `--visibility public|public-edit|private|unlisted|unlisted-edit`.
 When omitted, page visibility inherits from `.wikihub/acl`; ACL-only
 `public-view` and `unlisted-view` directives are returned as page-level
-`public` and `unlisted`.
+`public` and `unlisted`. Unlisted pages are readable by direct URL and appear
+in that wiki's own navigation/sidebar for viewers who can read them, but remain
+excluded from discovery surfaces such as search, explore, and profiles.
 
 ## Auth
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1300,6 +1300,64 @@ def test_sidebar_json_preserves_current_path_and_acl_shares(app, client, api_key
     assert secret["current"] is True, "current shared page should be marked current in async sidebar JSON"
 
 
+def test_unlisted_page_in_sidebar_but_not_discovery(app, client, api_key):
+    """wikihub #17: 'unlisted' governs DISCOVERY surfaces (search/explore/profile),
+    NOT in-wiki navigation. An anonymous viewer who possesses the wiki link and can
+    read a page (unlisted is readable-by-URL) must see it in the wiki's own sidebar
+    page tree. Both directions are asserted:
+
+      (A) fix     — anon sidebar of the wiki LISTS the unlisted page.
+      (B) guard   — search still EXCLUDES the unlisted page (discovery surface).
+
+    Regression: before the fix, _visible_files filtered the public-mirror sidebar
+    by is_discoverable (public/public-edit only), so unlisted pages rendered by
+    direct link but never appeared in nav.
+    """
+    h = {"Authorization": f"Bearer {api_key}"}
+
+    # wiki creation auto-provisions a public index.md, so the wiki is reachable.
+    r = client.post("/api/v1/wikis", json={"slug": "unlisted-nav", "title": "Unlisted Nav"}, headers=h)
+    assert r.status_code == 201, f"setup wiki create failed: {r.status_code} {r.data[:200]}"
+
+    # an unlisted page carrying a unique token
+    r = client.post("/api/v1/wikis/agent1/unlisted-nav/pages", json={
+        "path": "rules.md",
+        "content": "---\ntitle: Rules\nvisibility: unlisted\n---\n\n# Rules\n\nZorptangle marker.",
+        "visibility": "unlisted",
+    }, headers=h)
+    assert r.status_code == 201, f"setup page create failed: {r.status_code} {r.data[:200]}"
+
+    anon = app.test_client()  # logged-out viewer
+
+    # unlisted page is readable by URL (the can_read premise the sidebar must honor)
+    r = anon.get("/@agent1/unlisted-nav/rules")
+    assert r.status_code == 200, f"unlisted page must be readable by direct link, got {r.status_code}"
+
+    # (A) unlisted page appears in the anonymous sidebar page tree
+    r = anon.get("/@agent1/unlisted-nav/sidebar.json")
+    assert r.status_code == 200, f"sidebar.json fetch failed: {r.status_code} {r.data[:200]}"
+
+    def find_item(items, path):
+        for item in items:
+            if item.get("path") == path:
+                return item
+            found = find_item(item.get("children") or [], path)
+            if found:
+                return found
+        return None
+
+    tree = r.get_json()
+    assert find_item(tree, "rules.md") is not None, \
+        "unlisted page must appear in the anon sidebar of its own wiki (wikihub #17)"
+
+    # (B) but the unlisted page stays out of discovery: anonymous search excludes it
+    r = anon.get("/api/v1/search?q=Zorptangle")
+    assert r.status_code == 200, f"search failed: {r.status_code} {r.data[:200]}"
+    hits = r.get_json()["results"]
+    assert all("rules.md" not in (hit.get("path") or "") for hit in hits), \
+        "unlisted page must NOT appear in search (discovery surface stays excluded)"
+
+
 def test_email_verification_flow(client):
     """wikihub-ks5t.3: signup with email is non-blocking — account works
     immediately, and a verification link is emailed. Clicking the link sets
@@ -6107,6 +6165,7 @@ def run_all():
             ("magic link login", lambda: test_magic_link_login(client)),
             ("sign-in flow redirects back to target (wikihub-kvwh)", lambda: test_signin_flow_redirects_back_to_target(app, client)),
             ("logout (wikihub-uq9)", lambda: test_logout(client)),
+            ("unlisted page in sidebar but not discovery (wikihub #17)", lambda: test_unlisted_page_in_sidebar_but_not_discovery(app, client, key)),
             ("email verification flow (wikihub-ks5t.3)", lambda: test_email_verification_flow(client)),
             ("password reset flow (wikihub-ks5t.5)", lambda: test_password_reset_lifecycle(client)),
             ("Google auto-link security (wikihub-ks5t.4)", lambda: test_google_auto_link_security(app)),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1354,7 +1354,7 @@ def test_unlisted_page_in_sidebar_but_not_discovery(app, client, api_key):
     r = anon.get("/api/v1/search?q=Zorptangle")
     assert r.status_code == 200, f"search failed: {r.status_code} {r.data[:200]}"
     hits = r.get_json()["results"]
-    assert all("rules.md" not in (hit.get("path") or "") for hit in hits), \
+    assert all(hit.get("page") != "rules.md" for hit in hits), \
         "unlisted page must NOT appear in search (discovery surface stays excluded)"
 
 


### PR DESCRIPTION
## Intent

Fix wikihub issue #17: the sidebar page list was empty for anonymous viewers of an unlisted wiki — pages rendered by direct link but never appeared in nav. Guiding principle (from the issue): 'unlisted' governs DISCOVERY surfaces (search/explore/profile listings), NOT in-wiki navigation. A viewer who possesses the wiki link and can read a page (unlisted is readable-by-URL, per the ACL work merged in PR #16) must see it in the wiki's own sidebar/page tree. Root cause: in app/routes/wiki.py, the public-mirror branch of _visible_files() filtered the sidebar tree through an is_discoverable set (public/public-view/public-edit only), excluding unlisted. The fix realigns that filter to can_read(path, rules, None, visibility), which admits public, public-edit, and unlisted — building on PR #16's ACL semantics, not regressing them. The public mirror already excludes private pages at generation time, so every file present there is readable-by-URL by construction. Deliberately kept the diff tight: only the one filter branch changed. Added a regression test (test_unlisted_page_in_sidebar_but_not_discovery) asserting BOTH directions: anon sidebar.json lists the unlisted page, while anon /api/v1/search still excludes it (discovery surface unchanged). Verified the test fails without the fix and the full e2e suite passes 94/0.

## What Changed

- Fixed in-wiki navigation so anonymous readers of an unlisted wiki can see readable unlisted pages in the wiki sidebar/page tree.
- Preserved discovery privacy by keeping unlisted pages out of anonymous search results while allowing direct-link and sidebar access within the wiki.
- Documented unlisted navigation semantics across the repo, CLI, and agent-facing docs, and added end-to-end regression coverage for the sidebar and search behavior.

## Risk Assessment

✅ Low: The change is tightly scoped to anonymous public-mirror sidebar filtering and a matching e2e regression guard, while the surrounding access helpers still preserve the intended split between readable-by-link unlisted pages and discovery/search surfaces.

## Testing

Default Postgres was unavailable due a local Postgres.app permission prompt, so I used an isolated PostgreSQL instance; the focused wikihub #17 regression passed, the rendered anonymous UI screenshot shows `rules` in the sidebar, API evidence shows search excludes the unlisted marker, and the full e2e suite passed (`103 passed, 0 failed`).

- Evidence: Anonymous reader page showing unlisted page in sidebar (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXQWG9VBCZT7MZBQDFG81F02/anonymous-unlisted-sidebar.png</code>)
<details>
<summary>Evidence: Anonymous sidebar.json includes rules.md</summary>

```text
[{"active":false,"ancestor_of_current":false,"children":{},"current":false,"kind":"page","name":"rules","path":"rules.md","updated_at":"2026-07-17T04:20:45.497982-07:00","url":"/@anonnav1784287244/unlisted-sidebar/rules","visibility":"unlisted"}]
```
</details>
<details>
<summary>Evidence: Anonymous search excludes unlisted marker</summary>

```text
{"results":[],"total":0}
```
</details>
<details>
<summary>Evidence: Rendered evidence page URL</summary>

```text
http://127.0.0.1:7818/@anonnav1784287244/unlisted-sidebar/rules
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `tests/test_e2e.py:1357` - The search regression guard checks `hit.get(&#34;path&#34;)`, but `/api/v1/search` returns the page path under the `page` key, so this assertion would still pass if the unlisted page leaked into search results. Change it to check `hit.get(&#34;page&#34;)` or assert no result has `page == &#34;rules.md&#34;`.

🔧 Fix: Fix unlisted search regression assertion
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected target diff between `a2c243f5d8dfa58f0391396b87a3aa8e4cfd9794..e56d3a3d56ea74c96012e8ae8a04684cc3a44867`.</code>
- <code>Attempted focused regression against default local Postgres; setup was blocked by Postgres.app trust-permission prompt, so I started a throwaway PostgreSQL instance inside the worktree on port `7817`.</code>
- <code>Ran focused regression: `PGPORT=7817 python3 - &lt;&lt;&#39;PY&#39; ... test_unlisted_page_in_sidebar_but_not_discovery(...) ... PY`.</code>
- <code>Started local Flask server on `127.0.0.1:7818`, created an anonymous test account/wiki/page via API, opened `/@&lt;user&gt;/unlisted-sidebar/rules` as a logged-out browser visitor, and captured screenshot evidence with Chrome headless.</code>
- <code>Captured API evidence with `curl` for `/@&lt;user&gt;/unlisted-sidebar/sidebar.json` and `/api/v1/search?q=Zorptangle`; verified `sidebar_has_rules_md=True` and `search_has_rules_md=False`.</code>
- <code>Ran full e2e suite: `PGPORT=7817 python3 tests/test_e2e.py`.</code>
- <code>Stopped the Flask server and throwaway PostgreSQL instance, then removed transient worktree artifacts `.tmp-pgdata`, `.tmp-pglog`, `.tmp-dev-repos`, and Python caches.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
