### PR TITLE
fix(wiki): distinguish restricted reads from missing pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,10 @@ Anonymous pages are marked `anonymous=True, claimable=True` by default. Any logg
 
 Pending invites (share-by-email-before-signup, wikihub-skp7) materialize when the user's email is verified — either via an invite-link token click (yjsv), Google OAuth auto-verify, or the standard verify-email flow. Basic wiki reading/writing on your own content works regardless.
 
+### 3.5 Restricted (403) is deliberately distinct from not-found (404) (wikihub-dkp8)
+
+A page/wiki that EXISTS but the caller can't read returns a **"This page is restricted"** screen (HTTP 403, or 401 for anonymous agent/markdown requests), NOT a 404. A truly-missing path stays 404. This intentionally leaks the *fact of existence* (never title/content/frontmatter) — the captain accepted that tradeoff for clarity, because private pages reading as 404 made users think the page was never created. The distinction lives in the read paths: `wiki_page` / `wiki_index` / folder handler in `app/routes/wiki.py` (helpers `_render_restricted` / `_restricted_json`) and `read_page` in `app/routes/api_wikis.py`; the MCP `wikihub_get_page` inherits it via the API status code. If a security-review tool flags "existence leak", that's the tool misunderstanding the product. Regression: `test_restricted_vs_not_found_distinction`.
+
 ### 4. Collaboration roadmap — phases
 
 Explicit phase ordering (Jacob 2026-04-22):

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ For the desktop reader side peek, append `?fragment=1` to a rendered page URL to
 Use `?meta=1` on the page-read API when a client only needs the latest
 `content_hash` and `updated_at` for lightweight change polling; it enforces the
 same read permissions as a full page read and does not return page content.
+Read failures distinguish missing from restricted content: a truly missing page
+returns `404 not_found`; an existing page the caller cannot read returns
+`403 forbidden` for authenticated callers, or `401 authentication_required`
+with `WWW-Authenticate` for anonymous API/markdown callers. The restricted
+response intentionally confirms existence without returning title, content, or
+frontmatter.
 
 Full docs at `/agents` when running.
 

--- a/app/routes/agent_surfaces.py
+++ b/app/routes/agent_surfaces.py
@@ -21,7 +21,7 @@ from app.url_utils import url_path_from_page_path
 MCP_TOOLS = [
     {"name": "whoami", "description": "Check auth status"},
     {"name": "search", "description": "Full-text search across wikis"},
-    {"name": "read_page", "description": "Read a page's content"},
+    {"name": "read_page", "description": "Read a page's content; 404 means missing, 403/401 means restricted"},
     {"name": "list_pages", "description": "List pages in a wiki"},
     {"name": "create_page", "description": "Create a page"},
     {"name": "update_page", "description": "Replace or patch a page"},
@@ -337,6 +337,12 @@ response:
 the response omits page content and enforces the same read permissions as a full
 page read.
 
+Read failures distinguish missing from restricted content. A truly missing page
+returns `404 not_found`; an existing page the caller cannot read returns
+`403 forbidden` for authenticated callers, or `401 authentication_required`
+with `WWW-Authenticate` for anonymous API/markdown callers. Restricted responses
+intentionally confirm existence but never include title, content, or frontmatter.
+
 ## git clone & push
 
 every wiki is a real git repo. use your API key as the password:
@@ -525,6 +531,9 @@ Or append `.md` to the URL.
 For rendered HTML without the full reader chrome, append `?fragment=1` to a
 page URL. The response is JSON `{title, html, url, path}` for the article body
 only and uses the same ACL checks as the full page route.
+For markdown, fragment, and full-page reads, a genuinely missing path stays 404;
+an existing path outside your access returns the restricted 403/401 signal
+without page fields.
 
 ## hosting non-markdown files
 

--- a/app/routes/api_wikis.py
+++ b/app/routes/api_wikis.py
@@ -646,7 +646,25 @@ def read_page(owner, slug, page_path):
     acl_rules = load_acl_rules(owner_user.username, wiki.slug)
     if not is_owner:
         if not can_read(page.path, acl_rules, user.username if user else None, page.visibility):
-            return {"error": "not_found", "message": "Page not found"}, 404
+            # wikihub-dkp8: the page EXISTS but the caller lacks read access.
+            # Return 403 (authed) / 401 (anon) so agents — including
+            # wikihub_get_page — can tell "restricted" apart from a 404
+            # "does not exist". Never leak title/content/frontmatter here.
+            if user:
+                return {
+                    "error": "forbidden",
+                    "message": "This page is restricted — it exists but you don't have access.",
+                    "sign_in_url": "https://wikihub.md/auth/login",
+                }, 403
+            resp = jsonify({
+                "error": "authentication_required",
+                "message": "This page is restricted — sign in to check your access.",
+                "sign_in_url": "https://wikihub.md/auth/login",
+            })
+            resp.status_code = 401
+            resp.headers["WWW-Authenticate"] = 'Bearer realm="wikihub"'
+            resp.headers["Cache-Control"] = "no-store"
+            return resp
 
     # Lightweight liveness poll (reader "page updated" indicator, wikihub live-reload).
     # Returns only the content_hash + updated_at without reading the file from the

--- a/app/routes/wiki.py
+++ b/app/routes/wiki.py
@@ -297,6 +297,36 @@ def _render_permission_error(owner, wiki, status_code=None):
     return render_template("permission_error.html", owner=owner, wiki=wiki), status_code
 
 
+def _render_restricted(owner, wiki):
+    """wikihub-dkp8: the resource EXISTS but the viewer can't read it.
+
+    Renders the distinct "This page is restricted" screen with 403 semantics
+    (existence acknowledged, no content/title/frontmatter leaked). Contrast with
+    a genuinely-missing path, which stays a plain 404 (`error.html`).
+    """
+    return render_template("permission_error.html", owner=owner, wiki=wiki, restricted=True), 403
+
+
+def _restricted_json():
+    """wikihub-dkp8: agent/markdown-facing counterpart to `_render_restricted`.
+
+    Existence acknowledged with 403 (authed) / 401 (anon) so agents can tell
+    "restricted" apart from a 404 "does not exist". Never leaks page fields.
+    """
+    from flask import jsonify, make_response
+    status = 401 if not current_user.is_authenticated else 403
+    body = {
+        "error": "authentication_required" if status == 401 else "forbidden",
+        "message": "This page is restricted — it exists but you don't have access.",
+        "sign_in_url": "https://wikihub.md/auth/login",
+    }
+    resp = make_response(jsonify(body), status)
+    resp.headers["Cache-Control"] = "no-store"
+    if status == 401:
+        resp.headers["WWW-Authenticate"] = 'Bearer realm="wikihub"'
+    return resp
+
+
 def _normalize_folder_path(raw_path):
     clean = (raw_path or "").replace("\\", "/").strip().strip("/")
     clean = clean.removesuffix("/index.md").removesuffix("/index").removesuffix(".md")
@@ -1004,6 +1034,11 @@ def wiki_index(username, slug):
     if content is None:
         items = _folder_listing(owner.username, wiki.slug, wiki, "", public=use_public, acl_filter_user=acl_filter_user)
         if use_public and not items:
+            # wikihub-dkp8: the wiki row EXISTS. If it has any pages this viewer
+            # simply can't see → restricted (403). Only a genuinely empty wiki
+            # (no pages at all) falls back to the ambiguous 404.
+            if Page.query.filter_by(wiki_id=wiki.id).count() > 0:
+                return _render_restricted(owner, wiki)
             return render_template("permission_error.html", owner=owner, wiki=wiki), 404
         return render_template(
             "folder.html",
@@ -1562,6 +1597,13 @@ def wiki_page(username, slug, page_path):
         page = Page.query.filter_by(wiki_id=wiki.id, path=page_path).first()
         file_vis = page.visibility if page else resolve_visibility(page_path, acl_rules)
         if not is_owner and not can_read(page_path, acl_rules, user_name, file_vis):
+            # wikihub-dkp8: a non-markdown file with an explicit Page row EXISTS
+            # but is restricted → 403 restricted screen (agents get JSON). Only a
+            # bare path with no Page row (unknown file) falls through to 404.
+            if page is not None:
+                if "text/html" not in request.headers.get("Accept", ""):
+                    return _restricted_json()
+                return _render_restricted(owner, wiki)
             abort(404)
         use_public = _use_public_repo(wiki, acl_rules)
         data = read_file_bytes_from_repo(owner.username, wiki.slug, page_path, public=use_public)
@@ -1668,6 +1710,15 @@ def wiki_page(username, slug, page_path):
         content_path, content = _folder_index_content(owner.username, wiki.slug, page_path, public=use_public)
         items = _folder_listing(owner.username, wiki.slug, wiki, page_path, public=use_public, acl_filter_user=acl_filter_user)
         if use_public and not content and not items:
+            # wikihub-dkp8: distinguish "folder exists but its pages are
+            # restricted" (403) from "no such folder" (404). A folder exists iff
+            # any page's path lives under it.
+            folder_prefix = page_path.strip("/") + "/"
+            has_hidden = Page.query.filter_by(wiki_id=wiki.id).filter(
+                Page.path.like(folder_prefix.replace("%", r"\%").replace("_", r"\_") + "%", escape="\\")
+            ).first() is not None
+            if has_hidden:
+                return _render_restricted(owner, wiki)
             return render_template("permission_error.html", owner=owner, wiki=wiki), 404
         breadcrumb = []
         running = []
@@ -1707,6 +1758,9 @@ def wiki_page(username, slug, page_path):
     is_owner = _is_owner(wiki)
 
     if page and not is_owner and not can_read(page.path, acl_rules, user_name, page.visibility):
+        # wikihub-dkp8: the page EXISTS but this viewer can't read it. Return a
+        # distinct "restricted" signal (403/401) instead of the ambiguous 404 —
+        # existence-but-no-access reads very differently from "never created".
         # wikihub-3rjt: agent requests (Accept: text/markdown, or .md suffix
         # with markdown Accept) must NOT receive HTML permission_error — that
         # would be parsed as the page's content. Return JSON 4xx with
@@ -1714,19 +1768,8 @@ def wiki_page(username, slug, page_path):
         wants_markdown_now = "text/markdown" in request.headers.get("Accept", "")
         is_md_url = raw_page_path.endswith(".md") or page_path.endswith(".md")
         if wants_markdown_now or (is_md_url and not request.headers.get("Accept", "").startswith("text/html")):
-            from flask import jsonify, make_response
-            status = 401 if not current_user.is_authenticated else 403
-            body = {
-                "error": "authentication_required" if status == 401 else "forbidden",
-                "message": "This page is private or doesn't exist",
-                "sign_in_url": "https://wikihub.md/auth/login",
-            }
-            resp = make_response(jsonify(body), status)
-            resp.headers["Cache-Control"] = "no-store"
-            if status == 401:
-                resp.headers["WWW-Authenticate"] = 'Bearer realm="wikihub"'
-            return resp
-        return render_template("permission_error.html", owner=owner, wiki=wiki), 404
+            return _restricted_json()
+        return _render_restricted(owner, wiki)
 
     use_public, acl_filter_user = _repo_access(wiki, acl_rules)
     # For individual pages: if the page is private, always read from authoritative repo

--- a/app/templates/agents.html
+++ b/app/templates/agents.html
@@ -129,6 +129,7 @@ curl -X POST {{ request.host_url }}api/v1/auth/magic-link \
   <div class="code-block"><pre>curl -X GET {{ request.host_url }}api/v1/wikis/myagent/research/pages/wiki/hello.md?meta=1 \
   -H 'Authorization: Bearer wh_...'</pre></div>
   <p>Use <code>?meta=1</code> when a client only needs <code>content_hash</code> and <code>updated_at</code> to detect that a readable page changed. The response omits page content and uses the same read permissions as a full page read.</p>
+  <p>Read failures distinguish missing from restricted content: a truly missing page returns <code>404 not_found</code>; an existing page outside the caller's read access returns <code>403 forbidden</code> when authenticated or <code>401 authentication_required</code> with <code>WWW-Authenticate</code> when anonymous. Restricted responses confirm existence but never include title, content, or frontmatter.</p>
 
   <h2>Plain English instructions</h2>
   <p>Paste this into Claude, ChatGPT, or any LLM assistant:</p>
@@ -217,6 +218,7 @@ wikihub mcp-config                # prints mcpServers JSON pre-filled</pre></div
   <h2>Content negotiation</h2>
   <p><code>Accept: text/markdown</code> on any page URL returns raw markdown. Or append <code>.md</code>.</p>
   <p>For rendered HTML without the full reader chrome, append <code>?fragment=1</code> to a page URL. The response is JSON with <code>title</code>, <code>html</code>, <code>url</code>, and <code>path</code>, and it uses the same ACL checks as the full page route.</p>
+  <p>For markdown, fragment, and full-page reads, a genuinely missing path stays <code>404</code>; an existing path outside your access returns the restricted <code>403</code>/<code>401</code> signal without page fields.</p>
 
   <h2>Discovery</h2>
   <ul>

--- a/app/templates/permission_error.html
+++ b/app/templates/permission_error.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Not found — wikihub{% endblock %}
+{% block title %}{% if restricted %}Restricted — wikihub{% else %}Not found — wikihub{% endif %}{% endblock %}
 
 {% block extra_css %}
 /* wikihub-dw8u: anchor content near top instead of vertical-center.
@@ -41,11 +41,27 @@
   <div class="lock-icon">
     <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
   </div>
+  {% if restricted %}
+  {# wikihub-dkp8: distinct "restricted" screen. The resource EXISTS but the
+     viewer lacks read access. We deliberately acknowledge existence (captain
+     accepted this small info-leak for clarity) while never rendering the
+     page's title, content, or frontmatter. #}
+  <h1>This page is restricted</h1>
+  {% if current_user.is_authenticated %}
+  <p>This page exists, but your account doesn't have access. Request access from
+    {% if owner %}<strong>@{{ owner.username }}</strong>{% else %}the owner{% endif %},
+    or try a different account.</p>
+  {% else %}
+  <p>This page exists, but it's private. Sign in to check whether you have access,
+    or request access from {% if owner %}<strong>@{{ owner.username }}</strong>{% else %}the owner{% endif %}.</p>
+  {% endif %}
+  {% else %}
   <h1>This page is private or doesn't exist</h1>
   {% if current_user.is_authenticated %}
   <p>If you think you should have access, try signing in with a different account or contact the owner.</p>
   {% else %}
   <p>If you think you should have access, try signing in or contact the owner.</p>
+  {% endif %}
   {% endif %}
   <div class="error-actions">
     {% if current_user.is_authenticated %}

--- a/cli/README.md
+++ b/cli/README.md
@@ -64,6 +64,12 @@ When omitted, page visibility inherits from `.wikihub/acl`; ACL-only
 in that wiki's own navigation/sidebar for viewers who can read them, but remain
 excluded from discovery surfaces such as search, explore, and profiles.
 
+`read` uses the REST page-read endpoint's access semantics: a missing page is
+`404 not_found`, while an existing page outside the active profile's read access
+is `403 forbidden` for authenticated callers or `401 authentication_required`
+for anonymous reads. Restricted responses confirm existence but never include
+the page title, content, or frontmatter.
+
 ## Auth
 
 Credentials are read in this order (first wins):

--- a/docs/MCP_CONNECTOR_BLUEPRINT.md
+++ b/docs/MCP_CONNECTOR_BLUEPRINT.md
@@ -32,7 +32,7 @@
 | DELETE | `/api/v1/wikis/<owner>/<slug>` | Required (owner) |
 | POST | `/api/v1/wikis/<owner>/<slug>/pages` | Required |
 | GET | `/api/v1/wikis/<owner>/<slug>/pages` | Optional |
-| GET | `/api/v1/wikis/<owner>/<slug>/pages/<path>` | Optional; `?meta=1` returns only `path`, `content_hash`, and `updated_at` for lightweight change polling after the same read ACL check |
+| GET | `/api/v1/wikis/<owner>/<slug>/pages/<path>` | Optional; `?meta=1` returns only `path`, `content_hash`, and `updated_at` for lightweight change polling after the same read ACL check. Missing pages return `404 not_found`; existing pages outside the caller's read access return `403 forbidden` when authenticated or `401 authentication_required` when anonymous, without title/content/frontmatter. |
 | PATCH | `/api/v1/wikis/<owner>/<slug>/pages/<path>` | Required |
 | DELETE | `/api/v1/wikis/<owner>/<slug>/pages/<path>` | Required |
 | POST | `/api/v1/wikis/<owner>/<slug>/pages/<path>/append-section` | Required |

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -37,6 +37,12 @@ structure, same per-request auth isolation, adapted to WikiHub's REST API
 † Creating pages on `public-edit` wikis is allowed anonymously — pass
 `anonymous: true`. Otherwise an api key is required.
 
+`wikihub_get_page` preserves WikiHub's restricted-vs-missing distinction from
+the REST API: missing pages are `404 not_found`; existing pages outside the
+caller's read access are `403 forbidden` with a key or `401
+authentication_required` without one. Restricted errors confirm the page exists
+but never include title, content, or frontmatter.
+
 ---
 
 ## Install

--- a/mcp-server/src/instructions.ts
+++ b/mcp-server/src/instructions.ts
@@ -47,6 +47,10 @@ KEY INVARIANTS
 - On public-edit wikis, anyone (even without a key) can create pages
   (AGENTS.md core principle 2). Pass anonymous=true to wikihub_create_page
   to do this explicitly.
+- A missing page is different from a restricted page: wikihub_get_page
+  reports 404 for genuinely missing content, and 403/401 when the page
+  exists but this key cannot read it. Restricted errors never include
+  title, content, or frontmatter.
 - Writes default to attributing via the MCP connector's provenance
   headers. The server records these in ApiKey.agent_name/agent_version.
 - Page URLs: https://wikihub.md/@owner/slug/path (drop trailing .md).

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -198,7 +198,7 @@ export function buildServer(
     {
       title: 'Read a WikiHub page',
       description:
-        'Fetch a single page\'s content and metadata. Respects ACL: private pages require an api key that can read them.',
+        'Fetch a single page\'s content and metadata. Respects ACL: 404 means missing; 403/401 means the page exists but this key cannot read it.',
       inputSchema: {
         owner: z.string().describe('Username of the wiki owner (no leading @)'),
         slug: z.string().describe('Wiki slug (e.g. "notes")'),
@@ -723,7 +723,7 @@ export function buildServer(
     {
       title: 'Fetch (ChatGPT DR shape)',
       description:
-        'Alias of wikihub_get_page with the shape ChatGPT Deep Research expects: returns {id, title, text, url, metadata}. `id` is the composite id returned by `search` (format: "owner/slug:path").',
+        'Alias of wikihub_get_page with the shape ChatGPT Deep Research expects: returns {id, title, text, url, metadata}. `id` is the composite id returned by `search` (format: "owner/slug:path"); 404 means missing, 403/401 means restricted.',
       inputSchema: { id: z.string().min(1) },
     },
     async ({ id }) => {

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -477,8 +477,11 @@ def test_binary_file_serving(client, api_key):
         "visibility": "private",
     }, headers=h)
     assert r.status_code == 201
+    # wikihub-dkp8: a private non-md Page row EXISTS, so anon gets a "restricted"
+    # signal (403/401), not a bare 404. Content must still not leak.
     r = anon_client.get("/@agent1/media-wiki/outside/private-via-page.txt")
-    assert r.status_code == 404, f"Page.visibility=private should block anon access, got {r.status_code}"
+    assert r.status_code in (401, 403), f"Page.visibility=private should block anon access with restricted status, got {r.status_code}"
+    assert b"secret" not in r.data, "restricted response must not leak file content"
 
     # Non-md Page rows must survive an index_repo_pages reset (regression: wikihub-0idv).
     # Previously index_repo_pages filtered out non-md, so any operation that triggered
@@ -919,8 +922,10 @@ def test_signin_flow_redirects_back_to_target(app, client):
     _g.pop("_login_user", None)
     anon = app.test_client()
     r = anon.get(target_path)
-    assert r.status_code == 404
-    assert b"This page is private or doesn't exist" in r.data
+    # wikihub-dkp8: existing-but-private page → restricted (403); the sign-in CTA
+    # must still round-trip back to the requested target.
+    assert r.status_code == 403
+    assert b"This page is restricted" in r.data
     assert f'/auth/login?next={encoded_target}'.encode() in r.data
 
     r = anon.get("/@signinowner/private-wiki/settings")
@@ -3590,9 +3595,11 @@ def test_permission_error_offers_request_access(client, api_key):
     }, headers=h)
     assert r.status_code == 201
 
+    # wikihub-dkp8: existing-but-private page → restricted (403), and the
+    # restricted screen still offers the request-access affordance.
     r = client.get("/@agent1/private-cta/team/secret")
-    assert r.status_code == 404
-    assert b"This page is private or doesn't exist" in r.data
+    assert r.status_code == 403
+    assert b"This page is restricted" in r.data
     assert b"Request access" in r.data
     assert b"/api/v1/access-requests" in r.data
 
@@ -4747,21 +4754,119 @@ def test_unauth_private_page_renders_permission_error_with_sign_in(client):
     anon = client.application.test_client()
     anon.get("/auth/logout", follow_redirects=False)
     r = anon.get("/@ffqtowner/ffqt-wiki/secret/summary")
-    # Must not be 200 (would leak existence + drop user on welcome page).
-    assert r.status_code in (401, 403, 404), (
-        f"unauth private page returned {r.status_code} (expected 401/403/404). "
+    # wikihub-dkp8: the page EXISTS but is private → distinct "restricted"
+    # screen with 403 (existence acknowledged), NOT the ambiguous 404.
+    assert r.status_code == 403, (
+        f"unauth private page returned {r.status_code} (expected 403 restricted). "
         "If 200, the app is leaking private content to anonymous users."
     )
     body = r.data.decode("utf-8", errors="replace")
-    # Must render the permission_error template (recognizable heading).
-    assert "This page is private or doesn't exist" in body, (
-        "expected permission_error.html template, got something else. "
+    # Must render the restricted variant of permission_error (recognizable heading).
+    assert "This page is restricted" in body, (
+        "expected restricted permission_error.html template, got something else. "
         "If welcome.html is returned, the nginx intercept or a Flask routing "
         "bug is hiding the real error template."
     )
+    # Must NOT leak page content/title.
+    assert "Secret" not in body and "Private." not in body, "restricted screen leaked page content/title"
     # Must contain a Sign in link with next= pointing back at the requested path.
     assert "/auth/login" in body, "permission_error.html missing /auth/login link"
     assert "Sign in" in body, "permission_error.html missing 'Sign in' CTA text"
+
+
+def test_restricted_vs_not_found_distinction(client):
+    """wikihub-dkp8: an existing-but-private page must read as "restricted"
+    (403 / 401), distinct from a genuinely-missing path (404), across the web
+    route, the API, and the owner-subdomain routing form. Truly-missing stays
+    404; unlisted and granted access stay 200. Content is never leaked.
+    """
+    # Owner sets up a private page, an unlisted page, and a public page.
+    r = client.post("/api/v1/accounts", json={"username": "dkp8owner"})
+    assert r.status_code == 201
+    key = r.get_json()["api_key"]
+    h = {"Authorization": f"Bearer {key}"}
+
+    r = client.post("/api/v1/wikis", json={"slug": "dkp8-wiki", "title": "DKP8"}, headers=h)
+    assert r.status_code == 201
+
+    # Give the wiki a user-subdomain-reachable owner + a page under a folder.
+    r = client.post("/api/v1/wikis/dkp8owner/dkp8-wiki/pages", json={
+        "path": "vault/secret.md",
+        "content": "# TopSecret\n\nZZSECRETMARKER body.",
+        "visibility": "private",
+    }, headers=h)
+    assert r.status_code == 201
+
+    r = client.post("/api/v1/wikis/dkp8owner/dkp8-wiki/pages", json={
+        "path": "unlisted-note.md",
+        "content": "# Unlisted\n\nReachable by link.",
+        "visibility": "unlisted",
+    }, headers=h)
+    assert r.status_code == 201
+
+    anon = client.application.test_client()
+    anon.get("/auth/logout")
+
+    # --- Case 1: anon on an existing private page → 403 restricted screen ---
+    r = anon.get("/@dkp8owner/dkp8-wiki/vault/secret")
+    assert r.status_code == 403, f"anon private page expected 403 restricted, got {r.status_code}"
+    body = r.data.decode("utf-8", errors="replace")
+    assert "This page is restricted" in body, "expected the restricted screen heading"
+    assert "ZZSECRETMARKER" not in body and "TopSecret" not in body, "restricted screen leaked content/title"
+
+    # --- Case 2: anon on a truly-missing path → 404 (not restricted) ---
+    r = anon.get("/@dkp8owner/dkp8-wiki/no/such/page")
+    assert r.status_code == 404, f"missing page expected 404, got {r.status_code}"
+    body = r.data.decode("utf-8", errors="replace")
+    assert "This page is restricted" not in body, "missing page must NOT show the restricted screen"
+
+    # --- Case 4: unlisted page stays readable by direct link (200) ---
+    r = anon.get("/@dkp8owner/dkp8-wiki/unlisted-note")
+    assert r.status_code == 200, f"unlisted page expected 200, got {r.status_code}"
+    assert b"Reachable by link" in r.data
+
+    # --- Case 6a (subdomain form): anon on the private page via owner subdomain → 403 ---
+    # A user subdomain (dkp8owner.wikihub.md) rewrites /<slug>/<path> → /@dkp8owner/<slug>/<path>.
+    r = anon.get("/dkp8-wiki/vault/secret", headers={"Host": "dkp8owner.wikihub.md"})
+    assert r.status_code == 403, f"subdomain-form private page expected 403, got {r.status_code}"
+    assert "This page is restricted" in r.data.decode("utf-8", errors="replace")
+    # subdomain-form missing path still 404
+    r = anon.get("/dkp8-wiki/vault/does-not-exist", headers={"Host": "dkp8owner.wikihub.md"})
+    assert r.status_code == 404, f"subdomain-form missing page expected 404, got {r.status_code}"
+
+    # --- Case 5 (API surface, mirrors wikihub_get_page): 403 vs 401 vs 404 ---
+    # Authenticated non-grantee → 403 forbidden (page exists, no access).
+    r = client.post("/api/v1/accounts", json={"username": "dkp8stranger"})
+    stranger_key = r.get_json()["api_key"]
+    hs = {"Authorization": f"Bearer {stranger_key}"}
+    r = client.get("/api/v1/wikis/dkp8owner/dkp8-wiki/pages/vault/secret.md", headers=hs)
+    assert r.status_code == 403, f"authed non-grantee API read expected 403, got {r.status_code}"
+    jb = r.get_json()
+    assert jb.get("error") == "forbidden"
+    assert "ZZSECRETMARKER" not in (jb.get("content") or ""), "API restricted response leaked content"
+
+    # Anonymous API read of the existing private page → 401 + WWW-Authenticate.
+    anon_api = client.application.test_client()
+    r = anon_api.get("/api/v1/wikis/dkp8owner/dkp8-wiki/pages/vault/secret.md")
+    assert r.status_code == 401, f"anon API read of private page expected 401, got {r.status_code}"
+    assert "WWW-Authenticate" in r.headers
+    assert r.get_json().get("error") == "authentication_required"
+
+    # API read of a truly-missing page → 404 not_found.
+    r = client.get("/api/v1/wikis/dkp8owner/dkp8-wiki/pages/nope/missing.md", headers=hs)
+    assert r.status_code == 404, f"missing page API read expected 404, got {r.status_code}"
+    assert r.get_json().get("error") == "not_found"
+
+    # --- Case 3: a granted user reads it (200) via both API and web session ---
+    r = client.post("/api/v1/wikis/dkp8owner/dkp8-wiki/share", json={
+        "pattern": "vault/secret.md",
+        "username": "dkp8stranger",
+        "role": "read",
+    }, headers=h)
+    assert r.status_code == 200
+    r = client.get("/api/v1/wikis/dkp8owner/dkp8-wiki/pages/vault/secret.md", headers=hs)
+    assert r.status_code == 200, f"granted user API read expected 200, got {r.status_code}"
+    assert "ZZSECRETMARKER" in r.get_json()["content"]
 
 
 def test_mobile_hamburger_exposes_hidden_nav_links():
@@ -6222,6 +6327,7 @@ def run_all():
             ("search modal mobile UX fixes (wikihub-zlgt)", lambda: test_search_modal_mobile_ux_fixes_wikihub_zlgt()),
             ("search detectScope subdomain URL form (wikihub-zlgt)", lambda: test_search_detect_scope_matches_subdomain_url_form_wikihub_zlgt()),
             ("unauth private page renders permission_error with Sign in (wikihub-ffqt)", lambda: test_unauth_private_page_renders_permission_error_with_sign_in(client)),
+            ("restricted (403) vs not-found (404) distinction (wikihub-dkp8)", lambda: test_restricted_vs_not_found_distinction(client)),
             ("mobile hamburger exposes hidden nav (wikihub-pz27)", lambda: test_mobile_hamburger_exposes_hidden_nav_links()),
             ("error pages iPad alignment fix (wikihub-dw8u)", lambda: test_error_page_ipad_alignment_fix()),
             ("md request for private page returns 4xx (wikihub-3rjt)", lambda: test_md_request_for_private_page_returns_json_4xx_not_landing(client)),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -6201,12 +6201,14 @@ def test_page_meta_liveness_endpoint(client, api_key):
     assert r.status_code == 200
     assert r.get_json()["content_hash"] != first_hash, "hash must change after edit"
 
-    # ACL: anon must NOT be able to poll a private page's hash.
+    # ACL: anon must NOT be able to poll a private page's hash. wikihub-dkp8
+    # intentionally distinguishes existing-but-restricted API reads from
+    # missing pages, so this is 401/403 instead of the old ambiguous 404.
     with app.test_request_context():
         logout_user()
     anon = app.test_client()
     r = anon.get("/api/v1/wikis/agent1/live-mix/pages/secret.md?meta=1")
-    assert r.status_code == 404, f"anon meta poll on private page leaked ({r.status_code})"
+    assert r.status_code in (401, 403), f"anon meta poll on private page expected restricted status, got {r.status_code}"
     assert "content_hash" not in (r.get_json() or {}), "meta leaked private hash to anon"
 
     # But anon CAN poll a public page (the KB / unlisted use case).


### PR DESCRIPTION
## Intent

Captain-requested (wikihub-dkp8): on WikiHub, distinguish 'page not found' from 'you lack access'. Previously an existing-but-private page returned the same 404/permission_error as a truly nonexistent path, repeatedly confusing users (private pages read as 'the bot never created the page'). Now: when a page/wiki EXISTS but the caller can't read it, return a distinct 'This page is restricted' screen with HTTP 403 semantics (401 with WWW-Authenticate for anonymous agent/markdown/JSON requests) including a sign-in prompt and, when signed in, a 'request access from @owner' hint; truly-nonexistent paths keep the 404. IMPORTANT deliberate tradeoff the captain explicitly accepted: this intentionally leaks the FACT of existence but never the title/content/frontmatter — so a security-review flag about 'existence leak' is expected and NOT a bug. Applied across web read paths (wiki_page markdown + non-markdown-file branches, wiki_index, folder handler) which also covers the owner-subdomain routing form since the middleware rewrites to the same routes; the API read_page endpoint; and MCP wikihub_get_page which inherits the distinction via the API status code + body. Helpers _render_restricted/_restricted_json added. Added regression test test_restricted_vs_not_found_distinction (anon-private 403, anon-missing 404, granted 200, unlisted 200, API 403/401/404, subdomain form) and updated existing private-page tests to expect the restricted screen. All 94 e2e tests pass. Also documented the invariant in AGENTS.md principle 3.5 so future agents don't 'fix' the intentional existence acknowledgement as a leak.

## What Changed
- Distinguishes restricted existing wiki/page reads from truly missing content across web routes, API reads, and MCP-facing responses, returning 403 or anonymous 401 semantics instead of collapsing everything to 404.
- Updates the permission error surface to show a restricted-page message with sign-in/request-access guidance without exposing private page content.
- Documents the restricted-vs-not-found invariant across agent and MCP docs, and adds end-to-end regression coverage for web, API, subdomain, granted, missing, and unlisted cases.

## Risk Assessment

✅ Low: The change is well-scoped to web/API read-path status handling and the new behavior is covered by targeted e2e regression cases; I did not find material merge-blocking risks in the changed code.

## Testing

Focused regression testing, product-level web/API evidence capture, and the full e2e suite were run against an isolated Postgres backend; after updating one stale test expectation for the new restricted API semantics, all 104 e2e tests passed.

- Evidence: Anonymous private page renders restricted screen (403) (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/anon-private-web-403-restricted.png</code>)
- Evidence: Missing page renders not-found screen (404) (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/anon-missing-web-404-not-found.png</code>)
- Evidence: Unlisted page remains readable by direct link (200) (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/anon-unlisted-web-200-readable.png</code>)
<details>
<summary>Evidence: Restricted vs not-found response transcript</summary>

```text
[
  {
    "case": "anon-private-web-403",
    "status": "HTTP/1.1 403 FORBIDDEN",
    "www_authenticate": "",
    "restricted_heading": true,
    "secret_marker_visible": false,
    "unlisted_content_visible": false,
    "json": null,
    "artifact": "/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/anon-private-web-403.html"
  },
  {
    "case": "anon-missing-web-404",
    "status": "HTTP/1.1 404 NOT FOUND",
    "www_authenticate": "",
    "restricted_heading": false,
    "secret_marker_visible": false,
    "unlisted_content_visible": false,
    "json": null,
    "artifact": "/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/anon-missing-web-404.html"
  },
  {
    "case": "anon-unlisted-web-200",
    "status": "HTTP/1.1 200 OK",
    "www_authenticate": "",
    "restricted_heading": false,
    "secret_marker_visible": false,
    "unlisted_content_visible": true,
    "json": null,
    "artifact": "/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/anon-unlisted-web-200.html"
  },
  {
    "case": "subdomain-private-web-403",
    "status": "HTTP/1.1 403 FORBIDDEN",
    "www_authenticate": "",
    "restricted_heading": true,
    "secret_marker_visible": false,
    "unlisted_content_visible": false,
    "json": null,
    "artifact": "/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/subdomain-private-web-403.html"
  },
  {
    "case": "api-authed-private-403",
    "status": "HTTP/1.1 403 FORBIDDEN",
    "www_authenticate": "",
    "restricted_heading": true,
    "secret_marker_visible": false,
    "unlisted_content_visible": false,
    "json": {
      "error": "forbidden",
      "message": "This page is restricted \u2014 it exists but you don't have access.",
      "sign_in_url": "https://wikihub.md/auth/login"
    },
    "artifact": "/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/api-authed-private-403.json"
  },
  {
    "case": "api-anon-private-401",
    "status": "HTTP/1.1 401 UNAUTHORIZED",
    "www_authenticate": "WWW-Authenticate: Bearer realm=\"wikihub\"",
    "restricted_heading": true,
    "secret_marker_visible": false,
    "unlisted_content_visible": false,
    "json": {
      "error": "authentication_required",
      "message": "This page is restricted \u2014 sign in to check your access.",
      "sign_in_url": "https://wikihub.md/auth/login"
    },
    "artifact": "/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/api-anon-private-401.json"
  },
  {
    "case": "api-missing-404",
    "status": "HTTP/1.1 404 NOT FOUND",
    "www_authenticate": "",
    "restricted_heading": false,
    "secret_marker_visible": false,
    "unlisted_content_visible": false,
    "json": {
      "error": "not_found",
      "message": "Page not found"
    },
    "artifact": "/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/api-missing-404.json"
  },
  {
    "case": "api-granted-private-200",
    "status": "HTTP/1.1 200 OK",
    "www_authenticate": "",
    "restricted_heading": false,
    "secret_marker_visible": true,
    "unlisted_content_visible": false,
    "json": {
      "anonymous": false,
      "author": null,
      "claimable": false,
      "content": "---\nvisibility: private\n---\n\n# TopSecret\n\nZZSECRETMARKER private body.",
      "content_hash": "d09ed646687ec93cdfb8d29bacce26dc752b47e5ec26eca2145ac97bd20f24db",
      "excerpt": "TopSecret ZZSECRETMARKER private body.",
      "frontmatter": {
        "visibility": "private"
      },
      "id": 19,
      "path": "vault/secret.md",
      "title": "secret",
      "updated_at": "2026-07-17T16:07:26.485499-07:00",
      "visibility": "private",
      "content_contains_secret_marker": true
    },
    "artifact": "/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS4ZY9Q7J5VX3G7K2RT3597/api-granted-private-200.json"
  }
]
```
</details>
<details>
<summary>Evidence: Anonymous private web 403 HTML</summary>

```text
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="UTF-8">
<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
<title>Restricted — wikihub</title>
<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
<link rel="manifest" href="/static/manifest.json">

<!-- PWA / iOS Add-to-Home-Screen polish -->
<meta name="apple-mobile-web-app-capable" content="yes">
<meta name="mobile-web-app-capable" content="yes">
<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
<meta name="apple-mobile-web-app-title" content="wikihub">
<meta name="application-name" content="wikihub">
<meta name="theme-color" content="#0f0e0c" media="(prefers-color-scheme: dark)">
<meta name="theme-color" content="#faf7f1" media="(prefers-color-scheme: light)">
<link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon-180.png">
<link rel="apple-touch-icon" href="/static/favicon.svg">
<!-- agent discovery: point AI agents at plain-markdown + LLM index. wikihub-5764 -->
<link rel="alternate" type="text/markdown" href="/AGENTS.md" title="Agent setup (markdown)">
<link rel="alternate" type="text/plain" href="/llms.txt" title="LLM index">
<meta property="og:title" content="Restricted — wikihub">
<meta property="og:description" content="GitHub for LLM wikis. Publish markdown knowledge bases in seconds.">
<meta property="og:type" content="website">
<meta property="og:site_name" content="wikihub">
<meta name="description" content="GitHub for LLM wikis. Publish markdown knowledge bases in seconds.">

<meta name="theme-color" content="#0f0e0c" media="(prefers-color-scheme: dark)">
<meta name="theme-color" content="#faf7f1" media="(prefers-color-scheme: light)">
<script>(function(){try{var t=localStorage.getItem('wikihubTheme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
<style>
/* ───────── THEME TOKENS — dark default ───────── */
:root {
  color-scheme: dark;

  /* surfaces — obsidian warm */
  --bg-base: #0f0e0c;
  --bg-surface: #191714;
  --bg-elevated: #221f1b;
  --bg-overlay: #2a2622;

  /* text — warm ink */
  --text-primary: #e8e0d4;
  --text-secondary: #b8ad9e;
  --text-tertiary: #887d6e;
  --text-muted: #5a5248;
  --text-on-accent: #0f0e0c;

  /* accent — amber/gold */
  --accent: #d4a04a;
  --accent-hover: #e0b35a;
  --accent-muted: rgba(212, 160, 74, 0.12);
  --accent-subtle: rgba(212, 160, 74, 0.06);
  --accent-glow: rgba(212, 160, 74, 0.22);

  /* semantic */
  --color-public: #7a9e6b;
  --color-private: #c45c3c;
  --color-unlisted: #b8ad9e;
  --color-edit: #d4a04a;
  --color-wikilink: #d4a04a;
  --color-wikilink-broken: #c45c3c;
  --color-external: #7a9bb5;
  --color-success: #7a9e6b;
  --color-warning: #d4a04a;
  --color-error: #c45c3c;
  --color-error-soft: #d88c75;

  /* tinted rgba triplets for inline rgba(x,x,x, alpha) use */
  --rgb-public: 122, 158, 107;
  --rgb-private: 196, 92, 60;
  --rgb-accent: 212, 160, 74;

  /* borders — warm tinted */
  --border-default: rgba(200, 180, 150, 0.08);
  --border-emphasis: rgba(200, 180, 150, 0.15);
  --border-strong: rgba(200, 180, 150, 0.25);
  --border-accent: rgba(212, 160, 74, 0.4);

  /* controls */
  --control-bg: rgba(0, 0, 0, 0.2);
  --control-bg-hover: rgba(200, 180, 150, 0.08);
  --control-border: rgba(200, 180, 150, 0.12);
  --search-trigger-bg: #1a1816;
  --menu-bg: rgba(25, 23, 20, 0.98);
  --scrim: rgba(0, 0, 0, 0.7);
  --scrim-soft: rgba(0, 0, 0, 0.4);
  --shadow-color: rgba(0, 0, 0, 0.35);
  --hover-preview-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
  --card-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);

  /* gradients (derived from tokens; light mode will re-point these) */
  --gradient-person-card: linear-gradient(180deg, rgba(212, 160, 74, 0.08), rgba(25, 23, 20, 0.95));
  --gradient-person-avatar: linear-gradient(135deg, rgba(212, 160, 74, 0.18), rgba(34, 31, 27, 1));
  --gradient-subtle-tint: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.01));

  /* typography */
  --font-body: 'Inter', -apple-system, sans-serif;
  --font-mono: 'IBM Plex Mono', 'Menlo', monospace;

  /* radius */
  --radius-sm: 4px;
  --radius-md: 6px;
  --radius-lg: 10px;
}

/* ───────── LIGHT PALETTE — warm paper under a desk lamp ───────── */
@media (prefers-color-scheme: light) {
  :root {
    color-scheme: light;

    /* warm paper under a desk lamp:
       base is the lit desk surface, surfaces sit above with real elevation
       (darker), not lighter — same direction as paper stacks catching shadow.
       Accent is amber (not bronze); shadows are warm, not gray. */
    --bg-base: #fbf5e8;       /* lit paper */
    --bg-surface: #f4e9d4;    /* card on the desk */
    --bg-elevated: #eddcbf;   /* lifted like a notebook */
    --bg-overlay: #e5d0a8;    /* overlay / popover */

    --text-primary: #2a1d0e;  /* warm sepia ink */
    --text-secondary: #574532;
    --text-tertiary: #7d6a4f;
    --text-muted: #a59070;
    --text-on-accent: #1a0f03;

    /* brand amber — richer than my first pass, still passes AA as link text */
    --accent: #a86212;
    --accent-hover: #c87918;
    --accent-muted: rgba(168, 98, 18, 0.15);
    --accent-subtle: rgba(168, 98, 18, 0.08);
    --accent-glow: rgba(212, 160, 74, 0.35);   /* lamp-glow focus ring */

    --color-public: #4a7a41;
    --color-private: #9a3e23;
    --color-unlisted: #7d6a4f;
    --color-edit: #a86212;
    --color-wikilink: #a86212;
    --color-wikilink-broken: #9a3e23;
    --color-external: #395a78;
    --color-success: #4a7a41;
    --color-warning: #a86212;
    --color-error: #9a3e23;
    --color-error-soft: #b25640;

    --rgb-public: 74, 122, 65;
    --rgb-private: 154, 62, 35;
    --rgb-accent: 168, 98, 18;

    /* borders tinted warm sepia */
    --border-default: rgba(90, 58, 18, 0.12);
    --border-emphasis: rgba(90, 58, 18, 0.22);
    --border-strong: rgba(90, 58, 18, 0.34);
    --border-accent: rgba(168, 98, 18, 0.50);

    --control-bg: rgba(255, 248, 230, 0.7);
    --control-bg-hover: rgba(90, 58, 18, 0.07);
    --control-border: rgba(90, 58, 18, 0.18);
    --search-trigger-bg: #eee0c6;
    --menu-bg: rgba(251, 245, 232, 0.98);
    --scrim: rgba(40, 25, 10, 0.40);
    --scrim-soft: rgba(40, 25, 10, 0.22);

    /* warm amber-tinted shadows — "desk lamp spill", not neutral gray */
    --shadow-color: rgba(90, 58, 18, 0.14);
    --hover-preview-shadow: 0 8px 28px rgba(90, 58, 18, 0.18);
    --card-shadow: 0 1px 2px rgba(90, 58, 18, 0.12);

    /* light-mode gradients — paper warmth, amber glow, no dark endpoints */
    --gradient-person-card: linear-gradient(180deg, rgba(212, 160, 74, 0.14), rgba(244, 233, 212, 1));
    --gradient-person-avatar: linear-gradient(135deg, rgba(212, 160, 74, 0.45), rgba(245, 215, 160, 1));
    --gradient-subtle-tint: linear-gradient(180deg, rgba(90, 58, 18, 0.035), rgba(90, 58, 18, 0.015));
  }
}

/* ───────── Explicit override beats media query ───────── */
html[data-theme="dark"] {
  color-scheme: dark;
  --bg-base: #0f0e0c; --bg-surface: #191714; --bg-elevated: #221f1b; --bg-overlay: #2a2622;
  --text-primary: #e8e0d4; --text-secondary: #b8ad9e; --text-tertiary: #887d6e; --text-muted: #5a5248;
  --text-on-accent: #0f0e0c;
  --accent: #d4a04a; --accent-hover: #e0b35a;
  --accent-muted: rgba(212, 160, 74, 0.12); --accent-subtle: rgba(212, 160, 74, 0.06);
  --accent-glow: rgba(212, 160, 74, 0.22);
  --color-public: #7a9e6b; --color-private: #c45c3c; --color-unlisted: #b8ad9e;
  --color-edit: #d4a04a; --color-wikilink: #d4a04a; --color-wikilink-broken: #c45c3c;
  --color-external: #7a9bb5; --color-success: #7a9e6b; --color-warning: #d4a04a; --color-error: #c45c3c;
  --color-error-soft: #d88c75;
  --rgb-public: 122, 158, 107; --rgb-private: 196, 92, 60; --rgb-accent: 212, 160, 74;
  --border-default: rgba(200, 180, 150, 0.08); --border-emphasis: rgba(200, 180, 150, 0.15);
  --border-strong: rgba(200, 180, 150, 0.25); --border-accent: rgba(212, 160, 74, 0.4);
  --control-bg: rgba(0, 0, 0, 0.2); --control-bg-hover: rgba(200, 180, 150, 0.08);

... [41683 bytes truncated] ...

cument.body.appendChild(newC);
        positionCard(newC, rect, depth);
        c.remove();
        stack[idx] = { el: newC, depth: depth };
      })
      .catch(function() { removeLoadingFromStack(); c.remove(); });
  }

  // wikihub-spwp: stub cards for wikilinks pointing at pages that do not exist.
  // .wikilink-broken is set by app/renderer.py:321 for unresolved [[links]].
  // Show a dedicated card (no fetch) so the preview doesn't silently vanish.
  function openStubPreview(linkEl, rect, depth) {
    var c = document.createElement('div');
    c.className = 'hover-preview stub';
    c.style.zIndex = 300 + depth;
    c.dataset.depth = depth;

    var label = document.createElement('div');
    label.className = 'hover-preview-stub-label';
    label.textContent = 'Stub';
    c.appendChild(label);

    var titleEl = document.createElement('div');
    titleEl.className = 'hover-preview-title';
    titleEl.textContent = linkEl.dataset.target || linkEl.textContent.trim();
    c.appendChild(titleEl);

    var body = document.createElement('div');
    body.className = 'hover-preview-stub-body';
    body.textContent = 'Page not created yet.';
    c.appendChild(body);

    var create = document.createElement('a');
    create.className = 'hover-preview-stub-create';
    create.textContent = 'Create this page →';
    create.href = linkEl.getAttribute('href');
    c.appendChild(create);

    c.addEventListener('mouseenter', function() { cancelClose(); });
    c.addEventListener('mouseleave', onCardLeave(depth));
    document.body.appendChild(c);
    positionCard(c, rect, depth);
    stack.push({ el: c, depth: depth });
  }

  // page-level hover detection — immediate, no delay
  var lastHoverEl = null;
  document.addEventListener('mouseover', function(e) {
    var el = e.target.closest('.wikilink, .article a[href^="/@"]');
    if (!el || el === lastHoverEl) return;
    if (el.closest('.hover-preview')) return;
    lastHoverEl = el;
    var href = el.getAttribute('href');
    if (!href || href.startsWith('#')) return;

    cancelClose();
    closeFromDepth(0);

    if (el.classList.contains('wikilink-broken')) {
      openStubPreview(el, el.getBoundingClientRect(), 0);
      return;
    }

    var parsed = parseWikiUrl(href);
    if (!parsed) return;
    openPreview(parsed, el.getBoundingClientRect(), 0);
  });

  document.addEventListener('mouseout', function(e) {
    var el = e.target.closest('.wikilink, .article a[href^="/@"]');
    if (!el) return;
    if (el.closest('.hover-preview')) return;
    var related = e.relatedTarget;
    if (related && related.closest && related.closest('.hover-preview')) return;
    lastHoverEl = null;
    closeAll();
  });

  // click anywhere outside cards closes entire stack (and any orphans)
  document.addEventListener('click', function(e) {
    if (e.target.closest('.hover-preview')) return;
    cancelClose();
    closeFromDepth(0);
    lastHoverEl = null;
  });
})();
</script>
<script>
// PWA: register service worker, handle "new version available", offer "Add to Home Screen"
(function() {
  if ('serviceWorker' in navigator) {
    window.addEventListener('load', function() {
      navigator.serviceWorker.register('/static/sw.js', { scope: '/' })
        .then(function(reg) {
          // Check for updates whenever the user returns to the tab
          document.addEventListener('visibilitychange', function() {
            if (document.visibilityState === 'visible') reg.update();
          });
          reg.addEventListener('updatefound', function() {
            var nw = reg.installing;
            if (!nw) return;
            nw.addEventListener('statechange', function() {
              if (nw.state === 'installed' && navigator.serviceWorker.controller) {
                // New version waiting — auto-activate on next nav
                nw.postMessage('SKIP_WAITING');
              }
            });
          });
        })
        .catch(function(){});
    });
  }

  // Add-to-Home-Screen: capture the install prompt; show a small banner on second visit
  var deferredPrompt = null;
  window.addEventListener('beforeinstallprompt', function(e) {
    e.preventDefault();
    deferredPrompt = e;
    try {
      var visits = parseInt(localStorage.getItem('wh_visit_count') || '0', 10) + 1;
      localStorage.setItem('wh_visit_count', String(visits));
      var dismissed = localStorage.getItem('wh_a2hs_dismissed');
      var alreadyInstalled = window.matchMedia && window.matchMedia('(display-mode: standalone)').matches;
      if (visits >= 2 && !dismissed && !alreadyInstalled) showA2HSBanner();
    } catch(e) {}
  });

  function showA2HSBanner() {
    if (document.getElementById('wh-a2hs')) return;
    var b = document.createElement('div');
    b.id = 'wh-a2hs';
    b.setAttribute('style',
      'position:fixed;left:12px;right:12px;bottom:max(12px,env(safe-area-inset-bottom));' +
      'z-index:300;background:var(--bg-elevated,#1a1814);color:var(--text-primary,#f3eee4);' +
      'border:1px solid var(--border-default,#2a2620);border-radius:12px;padding:12px 14px;' +
      'box-shadow:0 8px 32px rgba(0,0,0,0.35);display:flex;gap:12px;align-items:center;' +
      'font-size:0.875rem;line-height:1.4;max-width:480px;margin:0 auto;');
    b.innerHTML =
      '<div style="flex:1">Install <b>wikihub</b> to your home screen for a faster, full-screen reading experience.</div>' +
      '<button id="wh-a2hs-yes" style="background:var(--accent,#d4a04a);color:#18130a;border:none;border-radius:8px;padding:8px 12px;font-weight:600;cursor:pointer;font-family:inherit">Install</button>' +
      '<button id="wh-a2hs-no" style="background:transparent;color:var(--text-muted,#b8ad9e);border:none;cursor:pointer;font-family:inherit;padding:6px 4px" aria-label="Dismiss">✕</button>';
    document.body.appendChild(b);
    document.getElementById('wh-a2hs-yes').addEventListener('click', function() {
      if (!deferredPrompt) { b.remove(); return; }
      deferredPrompt.prompt();
      deferredPrompt.userChoice.then(function(choice) {
        if (choice.outcome === 'accepted') {
          try { localStorage.setItem('wh_a2hs_dismissed', '1'); } catch(e) {}
        }
        deferredPrompt = null;
        b.remove();
      });
    });
    document.getElementById('wh-a2hs-no').addEventListener('click', function() {
      try { localStorage.setItem('wh_a2hs_dismissed', '1'); } catch(e) {}
      b.remove();
    });
  }

  // Count this visit even if beforeinstallprompt never fires (iOS doesn't fire it)
  try {
    var v = parseInt(localStorage.getItem('wh_visit_count') || '0', 10) + 1;
    localStorage.setItem('wh_visit_count', String(v));
  } catch(e) {}
})();
</script>

<script>
(function() {
  var toggle = document.getElementById('request-access-toggle');
  var form = document.getElementById('request-access-form');
  var submit = document.getElementById('request-access-submit');
  var status = document.getElementById('request-access-status');
  if (!toggle || !form || !submit || !status) return;

  toggle.addEventListener('click', function() {
    form.style.display = form.style.display === 'none' ? 'flex' : 'none';
  });

  submit.addEventListener('click', async function() {
    status.textContent = 'Sending request...';
    submit.disabled = true;
    try {
      var body = {
        path: window.location.pathname,
        note: (document.getElementById('request-access-note') || {}).value || ''
      };
      var emailEl = document.getElementById('request-access-email');
      if (emailEl) body.email = emailEl.value || '';

      const res = await fetch('/api/v1/access-requests', {
        method: 'POST',
        headers: {'Content-Type': 'application/json'},
        body: JSON.stringify(body),
      });
      const data = await res.json();
      status.textContent = data.message || 'If access can be requested for this link, the owner has been notified.';
      form.style.display = 'none';
    } catch (err) {
      status.textContent = 'If access can be requested for this link, the owner has been notified.';
      form.style.display = 'none';
    } finally {
      submit.disabled = false;
    }
  });
})();
</script>

</body>
</html>
```
</details>
<details>
<summary>Evidence: Anonymous private API 401 response</summary>

```text
{"error":"authentication_required","message":"This page is restricted — sign in to check your access.","sign_in_url":"https://wikihub.md/auth/login"}
```
</details>
<details>
<summary>Evidence: Authenticated non-grantee API 403 response</summary>

```text
{"error":"forbidden","message":"This page is restricted — it exists but you don't have access.","sign_in_url":"https://wikihub.md/auth/login"}
```
</details>
<details>
<summary>Evidence: Missing API 404 response</summary>

```text
{"error":"not_found","message":"Page not found"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `python3.11 -m venv .venv-test && . .venv-test/bin/activate && pip install -q -r requirements.txt`
- <code>`initdb -D .pg-test -A trust --encoding=UTF8 --locale=C.UTF-8` plus `pg_ctl -D .pg-test ... start` on port 7543</code>
- `. .venv-test/bin/activate && PGPORT=7543 python3 - <<'PY' ... test_restricted_vs_not_found_distinction(client) ... PY`
- `DATABASE_URL=postgresql://localhost:7543/wikihub_test ... flask --app wsgi.py run --host 127.0.0.1 --port 7544`
- <code>`curl` seeded `evidenceowner/evidence-wiki` with a private page, unlisted page, and stranger account</code>
- <code>`curl -D ... -o ...` captured web HTML and API JSON for private 403/401, missing 404, unlisted 200, subdomain 403, and granted 200 cases</code>
- <code>`chrome-devtools-axi open ... &amp;&amp; chrome-devtools-axi screenshot ...` attempted screenshot capture; connector reported paths but did not create files</code>
- <code>`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --headless=new --screenshot=...` captured PNG screenshots for restricted, missing, and unlisted web pages</code>
- `python3 - <<'PY' ... assert saved evidence statuses, leak checks, WWW-Authenticate, and screenshot files ... PY`
- `. .venv-test/bin/activate && PGPORT=7543 python3 tests/test_e2e.py`
- <code>`bd create ...`, `bd update nsv-whkn --status in_progress`, `bd close nsv-whkn -r ...`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
