### PR TITLE
fix(renderer): resolve relative wiki links on subdomains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ host (`ubuntu@54.145.123.7`) — that's historical. Production is GCP now.
 - `app/acl.py` — CODEOWNERS-pattern ACL parser for `.wikihub/acl`
 - `app/git_backend.py` — git Smart HTTP (clone/push), ported from listhub
 - `app/git_sync.py` — DB→git plumbing (does NOT fire hooks), public mirror regeneration
-- `app/renderer.py` — markdown-it-py with wikilinks, KaTeX, footnotes, Obsidian embeds
+- `app/renderer.py` — markdown-it-py with wikilinks, KaTeX, footnotes, Obsidian embeds, wiki-relative link rewriting
 - `app/static/js/sidepeek.js` — desktop reader slide-over for same-wiki page links; fetches rendered body JSON via `?fragment=1`
 - `app/auth_utils.py` — password hashing, API key gen/verify, Bearer auth decorators
 - `app/routes/` — blueprints: main, auth, api, api_wikis, wiki, agent_surfaces, upload

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub for LLM wikis. A hosting platform for markdown knowledge bases with per-f
 - Per-file access control via `.wikihub/acl` (CODEOWNERS-pattern globs)
 - Agent-native: REST API, MCP server, content negotiation, `llms.txt`
 - Social: fork, star, explore, profiles
-- Rendering: KaTeX math, syntax highlighting, wikilinks, footnotes, Obsidian embeds
+- Rendering: KaTeX math, syntax highlighting, wikilinks, footnotes, Obsidian embeds, wiki-relative links
 - Reader side peek: same-wiki page links open in a right-side preview panel on desktop
 - Every wiki is a real git repo — clone, push, blame, bisect
 
@@ -159,7 +159,7 @@ app/
   acl.py             .wikihub/acl parser
   git_backend.py     git Smart HTTP (clone/push)
   git_sync.py        DB->git plumbing, public mirror regen
-  renderer.py        markdown-it pipeline
+  renderer.py        markdown-it pipeline, wikilinks, wiki-relative link rewriting
   auth_utils.py      password hashing, API keys, Bearer auth
   routes/            Flask blueprints
 cli/                 wikihub-cli Python package (REST wrapper)

--- a/app/renderer.py
+++ b/app/renderer.py
@@ -48,6 +48,7 @@ _GDOC_TOC_ANCHOR_RE = re.compile(r'<a href="#(h\.[a-z0-9]+)">(.*?)</a>', re.IGNO
 _HEADING_ID_RE = re.compile(r'<h[1-6]\s+id="([^"]+)"', re.IGNORECASE)
 # TOC entries end with a tab/spaces + a page number, e.g. "Feeds        3".
 _TRAILING_PAGENUM_RE = re.compile(r'[\s ]+\d+\s*$')
+_URI_SCHEME_RE = re.compile(r'^[A-Za-z][A-Za-z0-9+.-]*:')
 
 
 def _rewrite_gdoc_toc_anchors(html):
@@ -523,10 +524,7 @@ def render_page(content, wiki_owner=None, wiki_slug=None, current_page_path=None
             prefix = match.group(1)
             href = match.group(2)
             suffix = match.group(3)
-            # leave external URLs, protocol-relative, already-absolute paths,
-            # pure anchors, and non-navigational schemes untouched.
-            if href.startswith(("http://", "https://", "//", "/", "#",
-                                "mailto:", "tel:", "javascript:")):
+            if _URI_SCHEME_RE.match(href) or href.startswith(("//", "/", "#")):
                 return match.group(0)
             # split off ?query / #fragment so we resolve only the path part
             m = re.match(r'^([^?#]*)([?#].*)?$', href)

--- a/app/renderer.py
+++ b/app/renderer.py
@@ -13,6 +13,7 @@ pipeline: markdown-it-py with plugins for:
 """
 
 import re
+from urllib.parse import unquote
 
 from markdown_it import MarkdownIt
 from mdit_py_plugins.footnote import footnote_plugin
@@ -533,6 +534,8 @@ def render_page(content, wiki_owner=None, wiki_slug=None, current_page_path=None
             if not path_part:
                 # pure query/fragment (e.g. "?x=1", "#sec") — leave alone
                 return match.group(0)
+            path_part = unquote(path_part)
+            directory_link = path_part.endswith("/")
             # resolve ../path relative to the current page's directory
             resolved = posixpath.normpath(posixpath.join(page_dir, path_part))
             # a link that escapes the wiki root (../../x) has no sane wiki URL
@@ -547,6 +550,8 @@ def render_page(content, wiki_owner=None, wiki_slug=None, current_page_path=None
             else:
                 # already URL-form (no .md); just anchor it to the wiki root.
                 url = f"/@{wiki_owner}/{wiki_slug}/{url_path_from_page_path(resolved, strip_md=False)}"
+            if directory_link and not url.endswith("/"):
+                url += "/"
             return f'{prefix}{url}{tail}{suffix}'
 
         html = re.sub(r'(href=")([^"]+)(")', resolve_relative_link, html)

--- a/app/renderer.py
+++ b/app/renderer.py
@@ -539,7 +539,7 @@ def render_page(content, wiki_owner=None, wiki_slug=None, current_page_path=None
             # resolve ../path relative to the current page's directory
             resolved = posixpath.normpath(posixpath.join(page_dir, path_part))
             # a link that escapes the wiki root (../../x) has no sane wiki URL
-            if resolved.startswith("..") or resolved == ".":
+            if resolved == ".." or resolved.startswith("../") or resolved == ".":
                 return match.group(0)
             if resolved.endswith(".md"):
                 # prefer the canonical URL of a known page; otherwise still

--- a/app/renderer.py
+++ b/app/renderer.py
@@ -505,7 +505,15 @@ def render_page(content, wiki_owner=None, wiki_slug=None, current_page_path=None
 
     html = render_markdown(content, resolve_wikilinks=resolver if wiki_owner else None)
 
-    # resolve relative markdown links (e.g. ../raw/foo.md) against current page path
+    # Absolute-ize relative in-content links (wikihub-qmx6).
+    #
+    # Markdown like [topics](topics) or [notes](../raw/foo.md) renders as a
+    # host-relative href ("topics", "../raw/foo.md"). On the apex form
+    # (/@owner/slug/page) the browser resolves those against the page URL, but on
+    # the canonical *subdomain* form (sub.wikihub.md/slug — NO trailing slash) a
+    # bare "topics" resolves against the host root -> sub.wikihub.md/topics -> 404.
+    # Rewrite every relative link to an absolute /@owner/slug/... path so it
+    # resolves inside the wiki regardless of which host form served the page.
     if wiki_owner and wiki_slug and current_page_path:
         import posixpath
         from app.url_utils import url_path_from_page_path
@@ -515,19 +523,33 @@ def render_page(content, wiki_owner=None, wiki_slug=None, current_page_path=None
             prefix = match.group(1)
             href = match.group(2)
             suffix = match.group(3)
-            # only resolve relative .md links (not external URLs, anchors, or absolute paths)
-            if href.startswith(("http://", "https://", "/", "#", "mailto:")):
+            # leave external URLs, protocol-relative, already-absolute paths,
+            # pure anchors, and non-navigational schemes untouched.
+            if href.startswith(("http://", "https://", "//", "/", "#",
+                                "mailto:", "tel:", "javascript:")):
                 return match.group(0)
-            if not href.endswith(".md"):
+            # split off ?query / #fragment so we resolve only the path part
+            m = re.match(r'^([^?#]*)([?#].*)?$', href)
+            path_part = m.group(1)
+            tail = m.group(2) or ""
+            if not path_part:
+                # pure query/fragment (e.g. "?x=1", "#sec") — leave alone
                 return match.group(0)
-            # resolve ../path relative to current page's directory
-            resolved = posixpath.normpath(posixpath.join(page_dir, href))
-            # check if this resolves to a known page
-            page = known_pages.get(resolved)
-            if page:
-                url = f"/@{wiki_owner}/{wiki_slug}/{url_path_from_page_path(page.path, strip_md=True)}"
-                return f'{prefix}{url}{suffix}'
-            return match.group(0)
+            # resolve ../path relative to the current page's directory
+            resolved = posixpath.normpath(posixpath.join(page_dir, path_part))
+            # a link that escapes the wiki root (../../x) has no sane wiki URL
+            if resolved.startswith("..") or resolved == ".":
+                return match.group(0)
+            if resolved.endswith(".md"):
+                # prefer the canonical URL of a known page; otherwise still
+                # absolute-ize so the link is host-independent.
+                page = known_pages.get(resolved)
+                target = page.path if page else resolved
+                url = f"/@{wiki_owner}/{wiki_slug}/{url_path_from_page_path(target, strip_md=True)}"
+            else:
+                # already URL-form (no .md); just anchor it to the wiki root.
+                url = f"/@{wiki_owner}/{wiki_slug}/{url_path_from_page_path(resolved, strip_md=False)}"
+            return f'{prefix}{url}{tail}{suffix}'
 
         html = re.sub(r'(href=")([^"]+)(")', resolve_relative_link, html)
 

--- a/app/renderer.py
+++ b/app/renderer.py
@@ -8,6 +8,7 @@ pipeline: markdown-it-py with plugins for:
   - \\qty command expansion (physics package compat)
   - code highlighting (via highlight.js on client)
   - external links in new tab
+  - wiki-relative link rewriting for in-content markdown links
   - obsidian image embeds ![[image.png]] and ![[image.png|300]]
   - private band stripping (<!-- private -->...<!-- /private -->)
 """

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2413,6 +2413,92 @@ def test_folder_async_sidebar_passes_current_context(client, api_key):
     )
 
 
+def test_relative_links_resolve_inside_wiki_on_subdomain(client, api_key):
+    """wikihub-qmx6 REGRESSION: in-content relative links must resolve inside the
+    wiki even on the canonical subdomain root (no trailing slash).
+
+    Markdown like [Topics](topics) renders as a host-relative href="topics". On
+    the subdomain form (agent1.wikihub.md/rel-links — NO trailing slash) a bare
+    "topics" resolves against the host root -> /topics -> 404. The renderer must
+    absolute-ize every relative in-content link to /@owner/slug/... so it works
+    regardless of which host form (apex or subdomain) served the page.
+    """
+    import re as _re
+    from html.parser import HTMLParser
+
+    h = {"Authorization": f"Bearer {api_key}"}
+
+    r = client.post("/api/v1/wikis", json={"slug": "rel-links", "title": "Rel Links"}, headers=h)
+    assert r.status_code == 201
+
+    # index page with several relative in-content links: a bare slug, a nested
+    # relative path, and a relative .md link. All must become absolute.
+    # (a fresh wiki auto-creates index.md, so PUT rather than POST.)
+    r = client.put("/api/v1/wikis/agent1/rel-links/pages/index.md", json={
+        "content": (
+            "---\ntitle: Home\nvisibility: public\n---\n\n"
+            "# Home\n\n"
+            "- [Topics](topics)\n"
+            "- [Deals](deals)\n"
+            "- [Notes](notes/scratch.md)\n"
+            "- [External](https://example.com/topics)\n"
+            "- [Anchor](#home)\n"
+        ),
+        "visibility": "public",
+    }, headers=h)
+    assert r.status_code == 200, f"index update failed: {r.status_code} {r.data[:200]}"
+    for p in ("topics.md", "deals.md", "notes/scratch.md"):
+        r = client.post("/api/v1/wikis/agent1/rel-links/pages", json={
+            "path": p,
+            "content": f"---\ntitle: {p}\nvisibility: public\n---\n\n# {p}",
+            "visibility": "public",
+        }, headers=h)
+        assert r.status_code == 201
+
+    # Fetch the wiki ROOT via the subdomain host, no trailing slash — exactly the
+    # live repro. The subdomain middleware rewrites it to /@agent1/rel-links.
+    r = client.get("/rel-links", base_url="http://agent1.wikihub.md")
+    assert r.status_code == 200, (
+        f"subdomain wiki root should render, got {r.status_code} "
+        "(subdomain middleware may not be rewriting the host)"
+    )
+    html = r.data.decode()
+
+    # Extract ONLY the in-content article region — chrome links are separate.
+    m = _re.search(r'<article class="article">(.*?)</article>', html, _re.DOTALL)
+    assert m, "reader page missing <article class=\"article\"> content region"
+    article = m.group(1)
+
+    # Collect every href in the article body.
+    hrefs = []
+
+    class _Collect(HTMLParser):
+        def handle_starttag(self, tag, attrs):
+            if tag == "a":
+                for k, v in attrs:
+                    if k == "href" and v is not None:
+                        hrefs.append(v)
+
+    _Collect().feed(article)
+
+    # The relative page links must have been rewritten to absolute wiki paths.
+    assert "/@agent1/rel-links/topics" in hrefs, f"expected absolute topics link, got {hrefs}"
+    assert "/@agent1/rel-links/deals" in hrefs, f"expected absolute deals link, got {hrefs}"
+    assert "/@agent1/rel-links/notes/scratch" in hrefs, f"expected absolute nested link, got {hrefs}"
+
+    # Every in-content link must resolve inside the wiki: no bare host-relative
+    # link (one that the browser would resolve against the host root) may survive.
+    for href in hrefs:
+        if href.startswith(("http://", "https://", "//", "mailto:", "tel:")):
+            continue  # external — fine
+        if href.startswith("#"):
+            continue  # in-page anchor — fine
+        assert href.startswith("/@agent1/rel-links/"), (
+            f"in-content link {href!r} is not absolute inside the wiki — it would "
+            "resolve against the subdomain host root and 404 (wikihub-qmx6)."
+        )
+
+
 def test_wikipedia_urls(client, api_key):
     """Wikipedia-style URLs: underscores instead of %20, redirect %20 to underscore"""
     h = {"Authorization": f"Bearer {api_key}"}
@@ -6291,6 +6377,7 @@ def run_all():
             ("new folder UI", lambda: test_new_folder_ui(client)),
             ("sidebar indentation (wikihub-58c regression guard)", lambda: test_sidebar_indentation(client, key)),
             ("QR code affordance on reader page (wikihub-x622)", lambda: test_reader_qr_code_affordance(client, key)),
+            ("relative links resolve inside wiki on subdomain (wikihub-qmx6)", lambda: test_relative_links_resolve_inside_wiki_on_subdomain(client, key)),
             ("wikipedia-style URLs", lambda: test_wikipedia_urls(client, key)),
             ("sharing lifecycle", lambda: test_sharing_lifecycle(client, key)),
             ("wiki-level sharing", lambda: test_wiki_level_sharing(client, key)),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2442,6 +2442,8 @@ def test_relative_links_resolve_inside_wiki_on_subdomain(client, api_key):
             "- [Deals](deals)\n"
             "- [Folder](folder/)\n"
             "- [Encoded](Foo%20Bar.md)\n"
+            "- [Dotfile](..notes.md)\n"
+            "- [Dotdir](..2026/plan)\n"
             "- [Notes](notes/scratch.md)\n"
             "- [External](https://example.com/topics)\n"
             "- [Upper External](HTTPS://example.com/upper)\n"
@@ -2452,7 +2454,7 @@ def test_relative_links_resolve_inside_wiki_on_subdomain(client, api_key):
         "visibility": "public",
     }, headers=h)
     assert r.status_code == 200, f"index update failed: {r.status_code} {r.data[:200]}"
-    for p in ("topics.md", "deals.md", "folder/index.md", "Foo Bar.md", "notes/scratch.md"):
+    for p in ("topics.md", "deals.md", "folder/index.md", "Foo Bar.md", "..notes.md", "..2026/plan.md", "notes/scratch.md"):
         r = client.post("/api/v1/wikis/agent1/rel-links/pages", json={
             "path": p,
             "content": f"---\ntitle: {p}\nvisibility: public\n---\n\n# {p}",
@@ -2491,6 +2493,8 @@ def test_relative_links_resolve_inside_wiki_on_subdomain(client, api_key):
     assert "/@agent1/rel-links/deals" in hrefs, f"expected absolute deals link, got {hrefs}"
     assert "/@agent1/rel-links/folder/" in hrefs, f"expected absolute folder link with trailing slash, got {hrefs}"
     assert "/@agent1/rel-links/Foo_Bar" in hrefs, f"expected decoded encoded-file link, got {hrefs}"
+    assert "/@agent1/rel-links/..notes" in hrefs, f"expected dot-prefixed filename link, got {hrefs}"
+    assert "/@agent1/rel-links/..2026/plan" in hrefs, f"expected dot-prefixed folder link, got {hrefs}"
     assert "/@agent1/rel-links/notes/scratch" in hrefs, f"expected absolute nested link, got {hrefs}"
     assert "HTTPS://example.com/upper" in hrefs, f"expected explicit scheme link untouched, got {hrefs}"
     assert "ftp://example.com/file" in hrefs, f"expected explicit scheme link untouched, got {hrefs}"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2440,6 +2440,8 @@ def test_relative_links_resolve_inside_wiki_on_subdomain(client, api_key):
             "# Home\n\n"
             "- [Topics](topics)\n"
             "- [Deals](deals)\n"
+            "- [Folder](folder/)\n"
+            "- [Encoded](Foo%20Bar.md)\n"
             "- [Notes](notes/scratch.md)\n"
             "- [External](https://example.com/topics)\n"
             "- [Upper External](HTTPS://example.com/upper)\n"
@@ -2450,7 +2452,7 @@ def test_relative_links_resolve_inside_wiki_on_subdomain(client, api_key):
         "visibility": "public",
     }, headers=h)
     assert r.status_code == 200, f"index update failed: {r.status_code} {r.data[:200]}"
-    for p in ("topics.md", "deals.md", "notes/scratch.md"):
+    for p in ("topics.md", "deals.md", "folder/index.md", "Foo Bar.md", "notes/scratch.md"):
         r = client.post("/api/v1/wikis/agent1/rel-links/pages", json={
             "path": p,
             "content": f"---\ntitle: {p}\nvisibility: public\n---\n\n# {p}",
@@ -2487,6 +2489,8 @@ def test_relative_links_resolve_inside_wiki_on_subdomain(client, api_key):
     # The relative page links must have been rewritten to absolute wiki paths.
     assert "/@agent1/rel-links/topics" in hrefs, f"expected absolute topics link, got {hrefs}"
     assert "/@agent1/rel-links/deals" in hrefs, f"expected absolute deals link, got {hrefs}"
+    assert "/@agent1/rel-links/folder/" in hrefs, f"expected absolute folder link with trailing slash, got {hrefs}"
+    assert "/@agent1/rel-links/Foo_Bar" in hrefs, f"expected decoded encoded-file link, got {hrefs}"
     assert "/@agent1/rel-links/notes/scratch" in hrefs, f"expected absolute nested link, got {hrefs}"
     assert "HTTPS://example.com/upper" in hrefs, f"expected explicit scheme link untouched, got {hrefs}"
     assert "ftp://example.com/file" in hrefs, f"expected explicit scheme link untouched, got {hrefs}"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2442,6 +2442,9 @@ def test_relative_links_resolve_inside_wiki_on_subdomain(client, api_key):
             "- [Deals](deals)\n"
             "- [Notes](notes/scratch.md)\n"
             "- [External](https://example.com/topics)\n"
+            "- [Upper External](HTTPS://example.com/upper)\n"
+            "- [FTP](ftp://example.com/file)\n"
+            "- [SMS](sms:+15551234567)\n"
             "- [Anchor](#home)\n"
         ),
         "visibility": "public",
@@ -2485,11 +2488,14 @@ def test_relative_links_resolve_inside_wiki_on_subdomain(client, api_key):
     assert "/@agent1/rel-links/topics" in hrefs, f"expected absolute topics link, got {hrefs}"
     assert "/@agent1/rel-links/deals" in hrefs, f"expected absolute deals link, got {hrefs}"
     assert "/@agent1/rel-links/notes/scratch" in hrefs, f"expected absolute nested link, got {hrefs}"
+    assert "HTTPS://example.com/upper" in hrefs, f"expected explicit scheme link untouched, got {hrefs}"
+    assert "ftp://example.com/file" in hrefs, f"expected explicit scheme link untouched, got {hrefs}"
+    assert "sms:+15551234567" in hrefs, f"expected explicit scheme link untouched, got {hrefs}"
 
     # Every in-content link must resolve inside the wiki: no bare host-relative
     # link (one that the browser would resolve against the host root) may survive.
     for href in hrefs:
-        if href.startswith(("http://", "https://", "//", "mailto:", "tel:")):
+        if _re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", href) or href.startswith("//"):
             continue  # external — fine
         if href.startswith("#"):
             continue  # in-page anchor — fine


### PR DESCRIPTION
## Intent

Fix relative-link resolution on WikiHub subdomain wiki roots (live bug hit 2026-07-17). On the canonical subdomain wiki root (sub.wikihub.md/<slug>, no trailing slash), bare markdown links like [Topics](topics) rendered as host-relative href="topics"; the browser resolved that against the host root -> sub.wikihub.md/topics -> 404. Root cause: app/renderer.py only absolute-ized relative .md links, leaving plain URL-style relative links untouched. Fix: generalize the renderer's relative-link resolver so EVERY relative in-content link is rewritten to an absolute /@owner/slug/... path (resolved against the current page's repo directory), leaving external URLs, protocol-relative, already-absolute, anchor, and mailto/tel/javascript links alone, and skipping links that escape the wiki root (../..). This makes links host-independent and correct on both apex and subdomain routing forms, uniformly across page views, the wiki root, and folder indexes (all go through render_page with current_page_path). Chosen approach (b) render host-appropriate absolute paths rather than (a) trailing-slash redirect, because it fixes deep pages too and is host-independent. Sidebar/chrome links were already absolute /@user/... paths and route correctly on subdomains (middleware skips /@ paths), so no change needed there. Added an e2e regression test (test_relative_links_resolve_inside_wiki_on_subdomain) that fetches a subdomain wiki root via the middleware and asserts every in-content link resolves inside the wiki; verified it fails without the fix and passes with it. Full suite 94/94 pass. Ticket wikihub-qmx6.

## What Changed

- Reworked markdown rendering so relative in-content links are resolved against the current wiki page and emitted as absolute `/@owner/wiki/...` paths, fixing subdomain root and deep-page navigation.
- Preserved non-wiki hrefs and edge cases during rewriting, including explicit URI schemes, protocol-relative URLs, anchors, query-only links, trailing-slash directory links, percent-encoded paths, and valid dot-prefixed filenames.
- Added an end-to-end regression covering relative links on subdomain wiki roots, plus updated project docs to describe wiki-relative link behavior.

## Risk Assessment

✅ Low: The change is narrow, covers the intended relative-link edge cases with a focused e2e regression, and the remaining behavior matches the stated product intent.

## Testing

I inspected the patch, worked around a local Postgres.app permission block with an isolated throwaway PostgreSQL instance, exercised the subdomain wiki-root flow end to end, captured rendered HTML plus screenshot evidence of absolute in-content wiki links, and ran both targeted and broader e2e checks; the relative-link behavior passed, while the full suite had two unrelated order-sensitive failures that passed individually.

- Evidence: Rendered WikiHub page showing absolute in-content wiki links (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS93PKMKVE1V7F37EWVYF74/subdomain-relative-links-page.png</code>)
<details>
<summary>Evidence: Rendered subdomain wiki root HTML response</summary>

```text
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="UTF-8">
<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
<title>Home — Rel Links — wikihub</title>
<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
<link rel="manifest" href="/static/manifest.json">

<!-- PWA / iOS Add-to-Home-Screen polish -->
<meta name="apple-mobile-web-app-capable" content="yes">
<meta name="mobile-web-app-capable" content="yes">
<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
<meta name="apple-mobile-web-app-title" content="wikihub">
<meta name="application-name" content="wikihub">
<meta name="theme-color" content="#0f0e0c" media="(prefers-color-scheme: dark)">
<meta name="theme-color" content="#faf7f1" media="(prefers-color-scheme: light)">
<link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon-180.png">
<link rel="apple-touch-icon" href="/static/favicon.svg">
<!-- agent discovery: point AI agents at plain-markdown + LLM index. wikihub-5764 -->
<link rel="alternate" type="text/markdown" href="/AGENTS.md" title="Agent setup (markdown)">
<link rel="alternate" type="text/plain" href="/llms.txt" title="LLM index">
<meta property="og:title" content="Home — Rel Links">
<meta property="og:description" content="Home Topics Deals Folder Encoded Dotfile Dotdir Notes External Upper External FTP SMS Anchor Escapes wiki root">
<meta property="og:type" content="website">
<meta property="og:site_name" content="wikihub">
<meta name="description" content="Home Topics Deals Folder Encoded Dotfile Dotdir Notes External Upper External FTP SMS Anchor Escapes wiki root">

<meta name="theme-color" content="#0f0e0c" media="(prefers-color-scheme: dark)">
<meta name="theme-color" content="#faf7f1" media="(prefers-color-scheme: light)">
<script>(function(){try{var t=localStorage.getItem('wikihubTheme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
<style>
/* ───────── THEME TOKENS — dark default ───────── */
:root {
  color-scheme: dark;

  /* surfaces — obsidian warm */
  --bg-base: #0f0e0c;
  --bg-surface: #191714;
  --bg-elevated: #221f1b;
  --bg-overlay: #2a2622;

  /* text — warm ink */
  --text-primary: #e8e0d4;
  --text-secondary: #b8ad9e;
  --text-tertiary: #887d6e;
  --text-muted: #5a5248;
  --text-on-accent: #0f0e0c;

  /* accent — amber/gold */
  --accent: #d4a04a;
  --accent-hover: #e0b35a;
  --accent-muted: rgba(212, 160, 74, 0.12);
  --accent-subtle: rgba(212, 160, 74, 0.06);
  --accent-glow: rgba(212, 160, 74, 0.22);

  /* semantic */
  --color-public: #7a9e6b;
  --color-private: #c45c3c;
  --color-unlisted: #b8ad9e;
  --color-edit: #d4a04a;
  --color-wikilink: #d4a04a;
  --color-wikilink-broken: #c45c3c;
  --color-external: #7a9bb5;
  --color-success: #7a9e6b;
  --color-warning: #d4a04a;
  --color-error: #c45c3c;
  --color-error-soft: #d88c75;

  /* tinted rgba triplets for inline rgba(x,x,x, alpha) use */
  --rgb-public: 122, 158, 107;
  --rgb-private: 196, 92, 60;
  --rgb-accent: 212, 160, 74;

  /* borders — warm tinted */
  --border-default: rgba(200, 180, 150, 0.08);
  --border-emphasis: rgba(200, 180, 150, 0.15);
  --border-strong: rgba(200, 180, 150, 0.25);
  --border-accent: rgba(212, 160, 74, 0.4);

  /* controls */
  --control-bg: rgba(0, 0, 0, 0.2);
  --control-bg-hover: rgba(200, 180, 150, 0.08);
  --control-border: rgba(200, 180, 150, 0.12);
  --search-trigger-bg: #1a1816;
  --menu-bg: rgba(25, 23, 20, 0.98);
  --scrim: rgba(0, 0, 0, 0.7);
  --scrim-soft: rgba(0, 0, 0, 0.4);
  --shadow-color: rgba(0, 0, 0, 0.35);
  --hover-preview-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
  --card-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);

  /* gradients (derived from tokens; light mode will re-point these) */
  --gradient-person-card: linear-gradient(180deg, rgba(212, 160, 74, 0.08), rgba(25, 23, 20, 0.95));
  --gradient-person-avatar: linear-gradient(135deg, rgba(212, 160, 74, 0.18), rgba(34, 31, 27, 1));
  --gradient-subtle-tint: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.01));

  /* typography */
  --font-body: 'Inter', -apple-system, sans-serif;
  --font-mono: 'IBM Plex Mono', 'Menlo', monospace;

  /* radius */
  --radius-sm: 4px;
  --radius-md: 6px;
  --radius-lg: 10px;
}

/* ───────── LIGHT PALETTE — warm paper under a desk lamp ───────── */
@media (prefers-color-scheme: light) {
  :root {
    color-scheme: light;

    /* warm paper under a desk lamp:
       base is the lit desk surface, surfaces sit above with real elevation
       (darker), not lighter — same direction as paper stacks catching shadow.
       Accent is amber (not bronze); shadows are warm, not gray. */
    --bg-base: #fbf5e8;       /* lit paper */
    --bg-surface: #f4e9d4;    /* card on the desk */
    --bg-elevated: #eddcbf;   /* lifted like a notebook */
    --bg-overlay: #e5d0a8;    /* overlay / popover */

    --text-primary: #2a1d0e;  /* warm sepia ink */
    --text-secondary: #574532;
    --text-tertiary: #7d6a4f;
    --text-muted: #a59070;
    --text-on-accent: #1a0f03;

    /* brand amber — richer than my first pass, still passes AA as link text */
    --accent: #a86212;
    --accent-hover: #c87918;
    --accent-muted: rgba(168, 98, 18, 0.15);
    --accent-subtle: rgba(168, 98, 18, 0.08);
    --accent-glow: rgba(212, 160, 74, 0.35);   /* lamp-glow focus ring */

    --color-public: #4a7a41;
    --color-private: #9a3e23;
    --color-unlisted: #7d6a4f;
    --color-edit: #a86212;
    --color-wikilink: #a86212;
    --color-wikilink-broken: #9a3e23;
    --color-external: #395a78;
    --color-success: #4a7a41;
    --color-warning: #a86212;
    --color-error: #9a3e23;
    --color-error-soft: #b25640;

    --rgb-public: 74, 122, 65;
    --rgb-private: 154, 62, 35;
    --rgb-accent: 168, 98, 18;

    /* borders tinted warm sepia */
    --border-default: rgba(90, 58, 18, 0.12);
    --border-emphasis: rgba(90, 58, 18, 0.22);
    --border-strong: rgba(90, 58, 18, 0.34);
    --border-accent: rgba(168, 98, 18, 0.50);

    --control-bg: rgba(255, 248, 230, 0.7);
    --control-bg-hover: rgba(90, 58, 18, 0.07);
    --control-border: rgba(90, 58, 18, 0.18);
    --search-trigger-bg: #eee0c6;
    --menu-bg: rgba(251, 245, 232, 0.98);
    --scrim: rgba(40, 25, 10, 0.40);
    --scrim-soft: rgba(40, 25, 10, 0.22);

    /* warm amber-tinted shadows — "desk lamp spill", not neutral gray */
    --shadow-color: rgba(90, 58, 18, 0.14);
    --hover-preview-shadow: 0 8px 28px rgba(90, 58, 18, 0.18);
    --card-shadow: 0 1px 2px rgba(90, 58, 18, 0.12);

    /* light-mode gradients — paper warmth, amber glow, no dark endpoints */
    --gradient-person-card: linear-gradient(180deg, rgba(212, 160, 74, 0.14), rgba(244, 233, 212, 1));
    --gradient-person-avatar: linear-gradient(135deg, rgba(212, 160, 74, 0.45), rgba(245, 215, 160, 1));
    --gradient-subtle-tint: linear-gradient(180deg, rgba(90, 58, 18, 0.035), rgba(90, 58, 18, 0.015));
  }
}

/* ───────── Explicit override beats media query ───────── */
html[data-theme="dark"] {
  color-scheme: dark;
  --bg-base: #0f0e0c; --bg-surface: #191714; --bg-elevated: #221f1b; --bg-overlay: #2a2622;
  --text-primary: #e8e0d4; --text-secondary: #b8ad9e; --text-tertiary: #887d6e; --text-muted: #5a5248;
  --text-on-accent: #0f0e0c;
  --accent: #d4a04a; --accent-hover: #e0b35a;
  --accent-muted: rgba(212, 160, 74, 0.12); --accent-subtle: rgba(212, 160, 74, 0.06);
  --accent-glow: rgba(212, 160, 74, 0.22);
  --color-public: #7a9e6b; --color-private: #c45c3c; --color-unlisted: #b8ad9e;
  --color-edit: #d4a04a; --color-wikilink: #d4a04a; --color-wikilink-broken: #c45c3c;
  --color-external: #7a9bb5; --color-success: #7a9e6b; --color-warning: #d4a04a; --color-error: #c45c3c;
  --color-error-soft: #d88c75;
  --rgb-public: 122, 158, 107; --rgb-private: 196, 92, 60; --rgb-accent: 212, 160, 74;
  --border-default: rgba(200, 180, 150, 0.08); --border-emphasis: rgba(200, 180, 150, 0.15);
  --border-strong: rgba(200, 180, 150, 0.25); --border-accent: rgba(212, 160, 

... [116785 bytes truncated] ...

ry {
    const response = await fetch('/api/v1/agent/chat', {
      method: 'POST',
      headers: { 'Content-Type': 'application/json' },
      body: JSON.stringify({
        message: message,
        conversation_id: curatorConversationId,
        context: {
          owner: "agent1",
          wiki: "rel-links",
          page_path: "index.md"
        }
      })
    });

    if (!response.ok) {
      const err = await response.json().catch(() => ({}));
      msgDiv.textContent = 'Error: ' + (err.message || response.statusText);
      sendBtn.disabled = false;
      return;
    }

    const reader = response.body.getReader();
    const decoder = new TextDecoder();
    let buffer = '';
    let fullText = '';

    while (true) {
      const { done, value } = await reader.read();
      if (done) break;

      buffer += decoder.decode(value, { stream: true });
      const lines = buffer.split('\n');
      buffer = lines.pop();

      for (const line of lines) {
        if (!line.startsWith('data: ')) continue;
        let data;
        try { data = JSON.parse(line.slice(6)); } catch (e) { continue; }

        if (data.conversation_id) {
          curatorConversationId = data.conversation_id;
        }

        if (data.type === 'text') {
          fullText += data.content;
          msgDiv.innerHTML = curatorRenderMarkdown(fullText);
          const msgs = document.getElementById('curator-messages');
          msgs.scrollTop = msgs.scrollHeight;
        } else if (data.type === 'tool_use' && data.input && Object.keys(data.input).length > 0) {
          const toolDiv = document.createElement('div');
          toolDiv.className = 'tool-call';
          const inputStr = JSON.stringify(data.input, null, 2);
          toolDiv.innerHTML = '<details><summary>\u{1f527} ' + curatorEscape(data.name) + '</summary><pre>' + curatorEscape(inputStr) + '</pre></details>';
          msgDiv.appendChild(toolDiv);
        } else if (data.type === 'tool_result') {
          const lastTool = msgDiv.querySelector('.tool-call:last-child details');
          if (lastTool) {
            const resultPre = document.createElement('pre');
            resultPre.className = 'tool-result';
            const content = typeof data.content === 'string' ? data.content : JSON.stringify(data.content);
            resultPre.textContent = content.length > 800 ? content.slice(0, 800) + '...' : content;
            lastTool.appendChild(resultPre);
          }
        } else if (data.type === 'error') {
          const errP = document.createElement('p');
          errP.style.color = 'var(--color-private)';
          errP.textContent = data.content;
          msgDiv.appendChild(errP);
        }
      }
    }
  } catch (err) {
    msgDiv.textContent = 'Error: ' + err.message;
  } finally {
    sendBtn.disabled = false;
    document.getElementById('curator-input').focus();
  }
}

function curatorAppendMessage(role, content) {
  const messages = document.getElementById('curator-messages');
  const div = document.createElement('div');
  div.className = 'curator-message ' + role;
  if (content) {
    if (role === 'user') {
      div.textContent = content;
    } else {
      div.innerHTML = curatorRenderMarkdown(content);
    }
  }
  messages.appendChild(div);
  messages.scrollTop = messages.scrollHeight;
  return div;
}

function curatorEscape(s) {
  const d = document.createElement('div');
  d.textContent = s;
  return d.innerHTML;
}

function curatorRenderMarkdown(text) {
  return text
    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
    .replace(/`([^`]+)`/g, '<code>$1</code>')
    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" style="color:var(--accent)">$1</a>')
    .replace(/\n\n/g, '</p><p>')
    .replace(/\n/g, '<br>')
    .replace(/^/, '<p>').replace(/$/, '</p>')
    .replace(/<p><\/p>/g, '');
}

// Auto-resize textarea + Enter to send
document.addEventListener('DOMContentLoaded', function() {
  const input = document.getElementById('curator-input');
  if (!input) return;
  input.addEventListener('keydown', function(e) {
    if (e.key === 'Enter' && !e.shiftKey) {
      e.preventDefault();
      sendCuratorMessage();
    }
  });
  input.addEventListener('input', function() {
    this.style.height = 'auto';
    this.style.height = Math.min(this.scrollHeight, 120) + 'px';
  });
});
</script>



<script type="application/ld+json">
{"@context": "https://schema.org", "@type": "Article", "author": {"@type": "Person", "name": "agent1"}, "dateModified": "2026-07-17T17:30:17.778887-07:00", "datePublished": "2026-07-17T17:30:17.494764-07:00", "headline": "Home", "license": "https://wikihub.md/terms"}
</script>




<script>window.__wikihubPeek = { base: "/@agent1/rel-links" };</script>
<script src="/static/js/sidepeek.js"></script>


<style>
#page-update-pill {
  position: fixed;
  left: 50%;
  bottom: 20px;
  transform: translateX(-50%) translateY(12px);
  z-index: 400;
  display: none;
  align-items: center;
  gap: 10px;
  padding: 8px 14px;
  background: var(--bg-elevated, #221f1b);
  border: 1px solid var(--border-accent, rgba(212, 160, 74, 0.4));
  border-radius: 999px;
  font-size: 0.8125rem;
  color: var(--text-primary, #e8e2d8);
  opacity: 0;
  transition: opacity .2s ease, transform .2s ease;
}
#page-update-pill.open { display: flex; opacity: 1; transform: translateX(-50%) translateY(0); }
#page-update-pill button {
  cursor: pointer;
  border: none;
  border-radius: 999px;
  padding: 4px 12px;
  font: inherit;
  font-weight: 600;
  background: var(--accent, #d4a04a);
  color: #1a1712;
}
#page-update-pill button:hover { background: var(--accent-hover, #e0b35a); }
#page-update-pill .pill-dot {
  width: 8px; height: 8px; border-radius: 50%;
  background: var(--accent, #d4a04a);
  flex: none;
}
</style>
<div id="page-update-pill" role="status" aria-live="polite">
  <span class="pill-dot" aria-hidden="true"></span>
  <span>Page updated</span>
  <button type="button" onclick="location.reload()">Reload</button>
</div>
<script>
(function () {
  var baseHash = "eed8321ac44bb2a989e876ffb3e5e4d3f1ee5f0484c5729af7c59860c477c2a3";
  if (!baseHash) return; // nothing to compare against

  var pathSegments = "index.md".split('/').map(encodeURIComponent).join('/');
  var metaUrl = '/api/v1/wikis/' + encodeURIComponent("agent1")
    + '/' + encodeURIComponent("rel-links")
    + '/pages/' + pathSegments + '?meta=1';

  var pill = document.getElementById('page-update-pill');
  var stopped = false;              // pill shown or hard-stopped: stop polling
  var timer = null;
  var lastInteraction = Date.now();
  var IDLE_LIMIT_MS = 30 * 60 * 1000; // pause after ~30min of no interaction

  function nextDelay() {
    // 20–30s with jitter
    return 20000 + Math.floor(Math.random() * 10000);
  }

  function schedule() {
    if (stopped) return;
    if (timer) clearTimeout(timer);
    timer = setTimeout(poll, nextDelay());
  }

  function showPill() {
    stopped = true;
    if (timer) clearTimeout(timer);
    pill.classList.add('open');
  }

  function poll() {
    if (stopped) return;
    if (document.hidden) { schedule(); return; }              // pause while hidden
    if (Date.now() - lastInteraction > IDLE_LIMIT_MS) { schedule(); return; } // pause when idle
    fetch(metaUrl, { headers: { 'Accept': 'application/json' }, credentials: 'same-origin' })
      .then(function (r) { return r.ok ? r.json() : null; })
      .then(function (data) {
        if (data && data.content_hash && data.content_hash !== baseHash) {
          showPill();
        } else {
          schedule();
        }
      })
      .catch(function () { schedule(); }); // network hiccup: never blocks, just retries
  }

  ['mousemove', 'keydown', 'scroll', 'touchstart'].forEach(function (evt) {
    window.addEventListener(evt, function () { lastInteraction = Date.now(); }, { passive: true });
  });

  document.addEventListener('visibilitychange', function () {
    if (!document.hidden && !stopped) {
      lastInteraction = Date.now();
      poll(); // check immediately on returning to the tab
    }
  });

  schedule();
})();
</script>

</body>
</html>
```
</details>
<details>
<summary>Evidence: Extracted article hrefs from rendered response</summary>

```text
{
  "request_url": "http://agent1.wikihub.md/rel-links",
  "article_hrefs": [
    "/@agent1/rel-links/topics",
    "/@agent1/rel-links/deals",
    "/@agent1/rel-links/folder/",
    "/@agent1/rel-links/Foo_Bar",
    "/@agent1/rel-links/..notes",
    "/@agent1/rel-links/..2026/plan",
    "/@agent1/rel-links/notes/scratch",
    "https://example.com/topics",
    "HTTPS://example.com/upper",
    "ftp://example.com/file",
    "sms:+15551234567",
    "#home",
    "../../outside"
  ]
}
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (7m29s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `app/renderer.py:528` - The new relative-link rewrite only excludes a small, lowercase set of URI schemes. Links like `HTTPS://example.com`, `ftp://example.com/file`, `sms:+1555`, or other valid scheme URLs were previously left untouched because they do not end in `.md`, but now they are treated as wiki-relative paths and rewritten under `/@owner/slug/...`. Use a case-insensitive generic scheme check (for example `^[A-Za-z][A-Za-z0-9+.-]*:`) before resolving the path, while still handling `//`, `/`, `#`, and query-only links separately.

🔧 Fix: Preserve explicit scheme links
2 warnings still open:
- ⚠️ `app/renderer.py:537` - Trailing-slash relative folder links are normalized without preserving the slash, so `[Folder](topics/)` is rewritten to `/@owner/wiki/topics` instead of `/@owner/wiki/topics/`. The no-slash route tries `topics.md` first and 404s when the target is a folder with `topics/index.md`, while the original apex-relative link would have reached the folder route. Preserve a trailing slash before calling `url_path_from_page_path` for directory-style links.
- ⚠️ `app/renderer.py:549` - Percent-encoded relative hrefs are passed through `url_path_from_page_path` still encoded, which double-encodes `%` (`Foo%20Bar` becomes `Foo%2520Bar`) and no longer resolves to `Foo Bar.md` or similar files. Decode the path component before resolving/quoting it, while leaving the query/fragment tail untouched.

🔧 Fix: Preserve directory and encoded relative links
1 warning still open:
- ⚠️ `app/renderer.py:542` - The root-escape guard treats any resolved path starting with `..` as escaping the wiki, so valid same-directory page names like `..notes.md` or `..2026/plan` are left as relative hrefs and still break on the subdomain root. Check for the actual parent-directory segment instead, e.g. `resolved == &#39;..&#39; or resolved.startswith(&#39;../&#39;)`, so filenames that merely begin with two dots can still be absolute-ized.

🔧 Fix: Fix dot-prefixed relative link rewrites
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/test_e2e.py:1934` - The full `tests/test_e2e.py` run reached and passed the new wikihub-qmx6 regression, but exited nonzero from two order-sensitive failures: `anonymous public edit` and `sharing lifecycle`. Both failed tests passed when rerun individually in fresh app/test DB setup, so I did not identify them as regressions from the relative-link change.
- <code>Inspected the change with `git diff --stat 079dd48952828e193d0c660cec7a4c233cacb611..4ac679c87b974ee9cb00e930bf0f59fa518f7641` and reviewed the `app/renderer.py` / `tests/test_e2e.py` patch.</code>
- `Attempted the targeted regression against the default local Postgres and confirmed the environment was blocked by Postgres.app permission confirmation, then started an isolated temporary PostgreSQL data directory inside the worktree on port 7543.`
- <code>Ran targeted regression via `python3 - &lt;&lt;&#39;PY&#39; ... test_relative_links_resolve_inside_wiki_on_subdomain(client, key) ... PY` against isolated PostgreSQL; the first cleanup wrapper exited nonzero after printing the pass marker, then the evidence wrapper reran successfully.</code>
- <code>Generated end-to-end rendered evidence by creating `rel-links`, fetching `/rel-links` with `base_url=&#39;http://agent1.wikihub.md&#39;`, saving the HTML response, and asserting article hrefs include `/@agent1/rel-links/topics`, `/deals`, `/folder/`, `/Foo_Bar`, `/..notes`, `/..2026/plan`, and `/notes/scratch`.</code>
- <code>Captured reviewer-visible UI evidence with `chrome-devtools-axi open file:///var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXS93PKMKVE1V7F37EWVYF74/subdomain-relative-links-page.html` and `chrome-devtools-axi screenshot .../subdomain-relative-links-page.png`.</code>
- <code>Ran `PGPORT=7543 python3 tests/test_e2e.py`; the new relative-link regression passed inside the full suite, but the full command exited with two unrelated order-sensitive failures.</code>
- <code>Reran the two full-suite failures individually in fresh setup with `test_anonymous_public_edit` and `test_sharing_lifecycle`; both passed.</code>
- <code>Stopped the temporary PostgreSQL session and removed transient `.nm-test-pg`, `.nm-test-repos`, and `/tmp/wikihub-test-repos` test data.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
