### PR TITLE
feat: add activity feeds and RSS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ tests are intentional — each one verifies a real user flow end-to-end or a bro
 6. **agent surfaces** — all discovery endpoints respond (llms.txt, AGENTS.md, .well-known/*)
 7. **ACL permissions** — private pages not readable without auth
 8. **reader behavior** — sidebar, page controls, side peek, live updates, and other browser-facing regressions
+9. **activity feeds** — global activity excludes non-public content; RSS links are well-formed and visibility-safe
 
 don't add unit tests for individual functions. if something breaks, add an e2e test that covers the broken flow. tests should run in <10 seconds.
 
@@ -83,6 +84,7 @@ host (`ubuntu@54.145.123.7`) — that's historical. Production is GCP now.
 - `app/acl.py` — CODEOWNERS-pattern ACL parser for `.wikihub/acl`
 - `app/git_backend.py` — git Smart HTTP (clone/push), ported from listhub
 - `app/git_sync.py` — DB→git plumbing (does NOT fire hooks), public mirror regeneration
+- `app/feeds.py` — pure activity entry, relative time, and RSS formatting helpers
 - `app/renderer.py` — markdown-it-py with wikilinks, KaTeX, footnotes, Obsidian embeds, wiki-relative link rewriting
 - `app/static/js/sidepeek.js` — desktop reader slide-over for same-wiki page links; fetches rendered body JSON via `?fragment=1`
 - `app/auth_utils.py` — password hashing, API key gen/verify, Bearer auth decorators
@@ -96,7 +98,7 @@ host (`ubuntu@54.145.123.7`) — that's historical. Production is GCP now.
 - **DB→git sync does NOT fire hooks.** this prevents infinite sync loops.
 - **two repos per wiki:** `repos/<user>/<slug>.git` (authoritative) + `repos/<user>/<slug>-public.git` (derived mirror).
 - **frontmatter visibility wins over ACL file** (most specific wins).
-- **unlisted is readable-by-URL but not discoverable.** Link-holders who can read an unlisted page see it inside the wiki's own sidebar/page tree; search, explore, and profile listings still exclude it.
+- **unlisted is readable-by-URL but not globally discoverable.** Link-holders who can read an unlisted page see it inside the wiki's own sidebar/page tree and per-wiki RSS feed; search, explore, global activity/RSS, and profile listings still exclude it.
 - **pinned pages float to the top of the sidebar.** Frontmatter `pinned: true` on a page renders it in a top section of the wiki's left sidebar (subtle divider, then folders/pages alphabetical as usual). Frontmatter-wins, mirroring the visibility precedent. Read permissions still apply — a pinned page the viewer can't read simply doesn't appear. **Pin/unpin via the MCP `wikihub_update_page` tool by setting/removing `pinned: true` in the page's frontmatter — no dedicated tool.** Integrators (e.g. GroupBrain-provisioned wikis) can pin rules / chat-history pages the same way, by writing `pinned: true` frontmatter from their side. Implemented in `_build_sidebar_tree` (`app/routes/wiki.py`) + `render_sidebar` macro and async JS in `app/templates/reader.html`. Regression: `test_pinned_pages_sort_to_top`.
 - **empty nav/sidebar surfaces show explicit unconditional copy, never blankness.** A profile with no visible wikis/pages shows "No public pages here — this account may have unlisted content reachable by direct link."; a wiki sidebar with no visible pages shows "No listed pages visible to you." The wording is **identical whether or not unlisted content exists** — no information leak (same no-leak rule as the 403-vs-404 distinction). Zero-case profile wiki count reads "No public wikis". Regressions: `test_empty_sidebar_copy`, `test_empty_profile_copy_no_leak`.
 - **API keys start with `wh_`**, SHA-256 hashed in DB, shown once on creation.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GitHub for LLM wikis. A hosting platform for markdown knowledge bases with per-f
 - Publish markdown wikis instantly — drag-drop files or `git push`
 - Per-file access control via `.wikihub/acl` (CODEOWNERS-pattern globs)
 - Agent-native: REST API, MCP server, content negotiation, `llms.txt`
-- Social: fork, star, explore, profiles
+- Social: fork, star, explore, activity feeds, profiles
 - Rendering: KaTeX math, syntax highlighting, wikilinks, footnotes, Obsidian embeds, wiki-relative links
 - Reader side peek: same-wiki page links open in a right-side preview panel on desktop
 - Every wiki is a real git repo — clone, push, blame, bisect
@@ -82,8 +82,9 @@ Page `visibility` values are `public`, `public-edit`, `private`, `unlisted`,
 and `unlisted-edit`. When visibility is inherited from `.wikihub/acl`,
 ACL-only `public-view` and `unlisted-view` directives are reported as
 `public` and `unlisted` on the page. Unlisted pages are readable by direct
-URL and appear in that wiki's own navigation/sidebar for viewers who can read
-them, but stay out of discovery surfaces such as search, explore, and profiles.
+URL and appear in that wiki's own navigation/sidebar and per-wiki RSS feed for
+viewers who can read them, but stay out of global discovery surfaces such as
+search, explore, global activity, global RSS, and profiles.
 Set frontmatter `pinned: true` on a page to float it to the top of the wiki
 sidebar for viewers who can read it; pinning never overrides read permissions.
 
@@ -124,7 +125,8 @@ forms are accepted as aliases. Frontmatter `visibility:` on individual files
 overrides the ACL and is stored as the page-level enum: `public`, `public-edit`,
 `private`, `unlisted`, or `unlisted-edit`. Unlisted governs discovery, not
 in-wiki navigation: a link-holder who can read the page sees it in the wiki
-sidebar, while search/explore/profile listings still exclude it. Frontmatter
+sidebar and per-wiki RSS feed, while search/explore/global activity/profile
+listings still exclude it. Frontmatter
 `pinned: true` is also honored by the sidebar: pinned readable pages sort into
 a top section before the normal folder/page list.
 
@@ -156,7 +158,8 @@ Set `DATABASE_URL` and `REPOS_DIR` to run an isolated test lane without sharing
 the default `wikihub_test` database or `/tmp/wikihub-test-repos` directory.
 
 End-to-end tests cover account creation, wiki lifecycle, search, social, upload,
-agent surfaces, ACL permissions, reader behavior, live-update polling, and regression cases.
+activity feeds, agent surfaces, ACL permissions, reader behavior, live-update
+polling, and regression cases.
 
 ## Architecture
 
@@ -166,6 +169,7 @@ app/
   acl.py             .wikihub/acl parser
   git_backend.py     git Smart HTTP (clone/push)
   git_sync.py        DB->git plumbing, public mirror regen
+  feeds.py           Activity entry + RSS formatting helpers
   renderer.py        markdown-it pipeline, wikilinks, wiki-relative link rewriting
   auth_utils.py      password hashing, API keys, Bearer auth
   routes/            Flask blueprints

--- a/app/canonical_redirect.py
+++ b/app/canonical_redirect.py
@@ -33,6 +33,7 @@ _SKIP_SUFFIXES = (
     "/llms.txt", "/llms-full.txt",
     "/graph.json", "/sidebar.json", "/graph",
     "/history", "/commit",
+    "/activity", "/activity.rss",
     "/settings",
     "/reindex",
     "/preview",

--- a/app/canonical_redirect.py
+++ b/app/canonical_redirect.py
@@ -33,15 +33,18 @@ _SKIP_SUFFIXES = (
     "/llms.txt", "/llms-full.txt",
     "/graph.json", "/sidebar.json", "/graph",
     "/history", "/commit",
-    "/activity", "/activity.rss",
     "/settings",
     "/reindex",
     "/preview",
     "/new", "/new-folder",
 )
 
+_EXACT_SKIP_RE = re.compile(r"^/@[^/]+/[^/]+/(?:activity|activity\.rss)$")
+
 
 def _is_skipped(path: str) -> bool:
+    if _EXACT_SKIP_RE.match(path):
+        return True
     for s in _SKIP_SUFFIXES:
         if path.endswith(s) or s + "/" in path or path.endswith(s + "/"):
             return True

--- a/app/feeds.py
+++ b/app/feeds.py
@@ -1,0 +1,127 @@
+"""Activity feed helpers — shared by the global /activity page, /activity.rss,
+and per-wiki /@owner/slug/activity.rss.
+
+Visibility is enforced by the CALLERS at the query level (see routes). This
+module is pure formatting: turning Page rows into activity entries and RSS XML.
+"""
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from xml.sax.saxutils import escape
+
+from app.url_utils import url_path_from_page_path
+
+
+def relative_time(dt):
+    """Human 'x ago' string. Returns '' for None."""
+    if dt is None:
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    seconds = (datetime.now(timezone.utc) - dt).total_seconds()
+    if seconds < 0:
+        seconds = 0
+    if seconds < 60:
+        return "just now"
+    minute, hour, day, week, month, year = 60, 3600, 86400, 604800, 2592000, 31536000
+    if seconds < hour:
+        n = int(seconds // minute); return f"{n} minute{'s' if n != 1 else ''} ago"
+    if seconds < day:
+        n = int(seconds // hour); return f"{n} hour{'s' if n != 1 else ''} ago"
+    if seconds < week:
+        n = int(seconds // day); return f"{n} day{'s' if n != 1 else ''} ago"
+    if seconds < month:
+        n = int(seconds // week); return f"{n} week{'s' if n != 1 else ''} ago"
+    if seconds < year:
+        n = int(seconds // month); return f"{n} month{'s' if n != 1 else ''} ago"
+    n = int(seconds // year)
+    return f"{n} year{'s' if n != 1 else ''} ago"
+
+# How much clock skew (seconds) between created_at and updated_at still counts
+# as a "created" event rather than an "updated" one. Page create + initial
+# index write can land a few ms apart.
+_CREATE_WINDOW_SECONDS = 5
+
+
+def event_type_for_page(page):
+    """'created' if the page has never been meaningfully updated, else 'updated'."""
+    if page.created_at is None or page.updated_at is None:
+        return "updated"
+    delta = (page.updated_at - page.created_at).total_seconds()
+    return "created" if abs(delta) <= _CREATE_WINDOW_SECONDS else "updated"
+
+
+def author_for_page(page):
+    """Displayable author, or None. Anonymous pages never expose their author."""
+    if getattr(page, "anonymous", False):
+        return None
+    author = (page.author or "").strip()
+    return author or None
+
+
+def page_relative_url(owner_username, wiki_slug, page_path):
+    """Site-relative URL to a page (no host)."""
+    return f"/@{owner_username}/{wiki_slug}/{url_path_from_page_path(page_path, strip_md=True)}"
+
+
+def activity_entry(page, wiki, owner_username, host_url):
+    """Build a dict describing one activity event for templates + RSS.
+
+    host_url should be request.host_url (trailing slash ok).
+    """
+    rel = page_relative_url(owner_username, wiki_slug=wiki.slug, page_path=page.path)
+    title = (page.title or "").strip() or page.path
+    return {
+        "page_title": title,
+        "wiki_title": (wiki.title or wiki.slug),
+        "wiki_slug": wiki.slug,
+        "owner": owner_username,
+        "event": event_type_for_page(page),
+        "author": author_for_page(page),
+        "timestamp": page.updated_at,
+        "relative": relative_time(page.updated_at),
+        "rel_url": rel,
+        "abs_url": host_url.rstrip("/") + rel,
+    }
+
+
+def _rss_date(dt):
+    if dt is None:
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return format_datetime(dt.astimezone(timezone.utc))
+
+
+def render_rss(feed_title, feed_link, self_url, description, entries):
+    """Render a well-formed RSS 2.0 document.
+
+    entries: list of dicts from activity_entry(). Uses abs_url as guid+link.
+    """
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+        "<channel>",
+        f"<title>{escape(feed_title)}</title>",
+        f"<link>{escape(feed_link)}</link>",
+        f"<description>{escape(description)}</description>",
+        f'<atom:link href="{escape(self_url)}" rel="self" type="application/rss+xml" />',
+    ]
+    for e in entries:
+        verb = "created" if e["event"] == "created" else "updated"
+        item_title = f"{e['page_title']} ({verb} in {e['wiki_title']})"
+        desc_bits = [f"{verb.capitalize()} in {e['wiki_title']}"]
+        if e.get("author"):
+            desc_bits.append(f"by {e['author']}")
+        parts.extend(
+            [
+                "<item>",
+                f"<title>{escape(item_title)}</title>",
+                f"<link>{escape(e['abs_url'])}</link>",
+                f'<guid isPermaLink="false">{escape(e["abs_url"])}#{verb}-{_rss_date(e["timestamp"])}</guid>',
+                f"<pubDate>{_rss_date(e['timestamp'])}</pubDate>",
+                f"<description>{escape(' '.join(desc_bits))}</description>",
+                "</item>",
+            ]
+        )
+    parts.extend(["</channel>", "</rss>"])
+    return "\n".join(parts)

--- a/app/routes/agent_surfaces.py
+++ b/app/routes/agent_surfaces.py
@@ -59,6 +59,11 @@ def llms_txt():
         "- MCP: /mcp (add to your agent's mcpServers config)",
         "- CLI: `pipx install wikihub-cli` then `wikihub signup`, `wikihub write`, `wikihub read`, `wikihub search` (see /AGENTS.md)",
         "",
+        "## Discovery feeds",
+        "- [Recent activity](/activity): public page creations and updates",
+        "- [Recent activity RSS](/activity.rss): RSS for public page activity",
+        "- Per-wiki RSS: /@user/wiki/activity.rss includes pages readable in that wiki, including unlisted pages reachable by link",
+        "",
         "## Optional",
     ]
 
@@ -315,8 +320,9 @@ Page `visibility` values are `public`, `public-edit`, `private`, `unlisted`,
 and `unlisted-edit`. If omitted, the page inherits from `.wikihub/acl`; ACL-only
 `public-view` and `unlisted-view` directives are stored and reported as
 `public` and `unlisted` page visibility. Unlisted pages are readable by direct
-URL and appear in that wiki's own navigation/sidebar for viewers who can read
-them, but stay out of discovery surfaces such as search, explore, and profiles.
+URL and appear in that wiki's own navigation/sidebar and per-wiki RSS feed for
+viewers who can read them, but stay out of global discovery surfaces such as
+search, explore, global activity, global RSS, and profiles.
 Set frontmatter `pinned: true` to float a readable page to the top of the wiki
 sidebar; pinning never overrides read permissions and there is no dedicated
 pinning API or MCP tool.
@@ -566,6 +572,9 @@ and `X-Content-Type-Options: nosniff`.
 
 - `/llms.txt` — site-wide index
 - `/llms-full.txt` — all public pages
+- `/activity` — recent public page creations and updates
+- `/activity.rss` — RSS for recent public page activity
+- `/@user/wiki/activity.rss` — RSS for pages readable in that wiki, including unlisted pages reachable by link
 - `/.well-known/mcp/server-card.json` — MCP server card
 - `/.well-known/wikihub.json` — bootstrap manifest
 """

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -90,6 +90,72 @@ def explore():
     )
 
 
+def _global_activity_query():
+    """Pages across PUBLIC wikis only, newest activity first.
+
+    Strict no-leak: filtered at the query level to DISCOVERABLE_VISIBILITIES
+    (public / public-view / public-edit). Unlisted, private, and
+    public-edit-private-page content never appears here. Joined to Wiki + User
+    so callers get owner/wiki without N+1 lookups.
+    """
+    from app.discovery import DISCOVERABLE_VISIBILITIES
+
+    return (
+        db.session.query(Page, Wiki, User)
+        .join(Wiki, Page.wiki_id == Wiki.id)
+        .join(User, Wiki.owner_id == User.id)
+        .filter(Page.visibility.in_(DISCOVERABLE_VISIBILITIES))
+        .order_by(Page.updated_at.desc(), Page.id.desc())
+    )
+
+
+@main_bp.route("/activity")
+def activity():
+    """Site-wide activity feed across public wikis. Paginated."""
+    from app.feeds import activity_entry
+
+    try:
+        page_num = max(1, int(request.args.get("page", 1)))
+    except (TypeError, ValueError):
+        page_num = 1
+    per_page = 40
+
+    pagination = _global_activity_query().paginate(
+        page=page_num, per_page=per_page, error_out=False
+    )
+    entries = [
+        activity_entry(page, wiki, user.username, request.host_url)
+        for (page, wiki, user) in pagination.items
+    ]
+    return render_template(
+        "activity.html",
+        entries=entries,
+        pagination=pagination,
+        rss_url="/activity.rss",
+    )
+
+
+@main_bp.route("/activity.rss")
+def activity_rss():
+    """RSS 2.0 feed for the global public activity feed."""
+    from app.feeds import activity_entry, render_rss
+
+    rows = _global_activity_query().limit(50).all()
+    entries = [
+        activity_entry(page, wiki, user.username, request.host_url)
+        for (page, wiki, user) in rows
+    ]
+    site = request.host_url.rstrip("/")
+    xml = render_rss(
+        feed_title="WikiHub — recent activity",
+        feed_link=f"{site}/activity",
+        self_url=f"{site}/activity.rss",
+        description="Recent page creations and updates across public WikiHub wikis.",
+        entries=entries,
+    )
+    return current_app.response_class(xml, mimetype="application/rss+xml")
+
+
 @main_bp.route("/people")
 def people_index():
     return render_template("people.html", people=_people_directory())

--- a/app/routes/wiki.py
+++ b/app/routes/wiki.py
@@ -1484,18 +1484,31 @@ def wiki_activity_rss(username, slug):
 
     owner, wiki, _ = _get_owner_and_wiki_or_404(username, slug)
     acl_rules = load_acl_rules(owner.username, wiki.slug)
-    # Candidate pool bounded so a huge private wiki can't force a full scan;
-    # 300 newest is far more than the 50 we emit even after ACL filtering.
-    candidates = (
-        Page.query.filter_by(wiki_id=wiki.id)
-        .order_by(Page.updated_at.desc(), Page.id.desc())
-        .limit(300)
-        .all()
+    query = Page.query.filter_by(wiki_id=wiki.id)
+    has_acl_grants = (
+        current_user.is_authenticated
+        and acl_rules
+        and grants_for_user(acl_rules, current_user.username)
     )
-    visible = [
-        p for p in candidates
-        if _viewer_can_read_page(wiki, p, acl_rules=acl_rules, owner=owner)
-    ][:50]
+    if not _is_owner(wiki) and not has_acl_grants:
+        query = query.filter(Page.visibility.in_((
+            "public", "public-view", "public-edit",
+            "unlisted", "unlisted-view", "unlisted-edit",
+        )))
+    query = query.order_by(Page.updated_at.desc(), Page.id.desc())
+    visible = []
+    offset = 0
+    batch_size = 200
+    while len(visible) < 50:
+        candidates = query.offset(offset).limit(batch_size).all()
+        if not candidates:
+            break
+        for p in candidates:
+            if _viewer_can_read_page(wiki, p, acl_rules=acl_rules, owner=owner):
+                visible.append(p)
+                if len(visible) == 50:
+                    break
+        offset += batch_size
     entries = [
         activity_entry(p, wiki, owner.username, request.host_url) for p in visible
     ]

--- a/app/routes/wiki.py
+++ b/app/routes/wiki.py
@@ -1471,6 +1471,46 @@ def wiki_activity(username, slug):
     )
 
 
+@wiki_bp.route("/@<username>/<slug>/activity.rss")
+def wiki_activity_rss(username, slug):
+    """Per-wiki RSS feed.
+
+    Visibility mirrors the pages themselves: an anonymous request sees any page
+    it could reach by direct link (public AND unlisted), but never private
+    pages. Owners/grantees additionally see private pages (via can_read). We
+    reuse _viewer_can_read_page so ACL and frontmatter rules stay canonical.
+    """
+    from app.feeds import activity_entry, render_rss
+
+    owner, wiki, _ = _get_owner_and_wiki_or_404(username, slug)
+    acl_rules = load_acl_rules(owner.username, wiki.slug)
+    # Candidate pool bounded so a huge private wiki can't force a full scan;
+    # 300 newest is far more than the 50 we emit even after ACL filtering.
+    candidates = (
+        Page.query.filter_by(wiki_id=wiki.id)
+        .order_by(Page.updated_at.desc(), Page.id.desc())
+        .limit(300)
+        .all()
+    )
+    visible = [
+        p for p in candidates
+        if _viewer_can_read_page(wiki, p, acl_rules=acl_rules, owner=owner)
+    ][:50]
+    entries = [
+        activity_entry(p, wiki, owner.username, request.host_url) for p in visible
+    ]
+    site = request.host_url.rstrip("/")
+    wiki_url = f"{site}/@{owner.username}/{wiki.slug}"
+    xml = render_rss(
+        feed_title=f"{wiki.title or wiki.slug} — activity",
+        feed_link=wiki_url,
+        self_url=f"{wiki_url}/activity.rss",
+        description=f"Recent page activity in {wiki.title or wiki.slug}.",
+        entries=entries,
+    )
+    return Response(xml, mimetype="application/rss+xml")
+
+
 @wiki_bp.route("/@<username>/<slug>/<path:folder_path>/history")
 def page_history(username, slug, folder_path):
     """Page/folder history. wikihub-8888.1: ACL-gate against the specific page when one exists."""

--- a/app/routes/wiki.py
+++ b/app/routes/wiki.py
@@ -1484,6 +1484,8 @@ def wiki_activity_rss(username, slug):
 
     owner, wiki, _ = _get_owner_and_wiki_or_404(username, slug)
     acl_rules = load_acl_rules(owner.username, wiki.slug)
+    if not _viewer_can_see_any_page(wiki, acl_rules=acl_rules, owner=owner):
+        return _render_permission_error(owner, wiki)
     query = Page.query.filter_by(wiki_id=wiki.id)
     has_acl_grants = (
         current_user.is_authenticated

--- a/app/subdomain_middleware.py
+++ b/app/subdomain_middleware.py
@@ -29,6 +29,8 @@ _GLOBAL_PREFIXES = (
     "/static/",
     "/search",
     "/explore",
+    "/activity",
+    "/activity.rss",
     "/people",
     "/shared",
     "/roadmap",

--- a/app/subdomain_middleware.py
+++ b/app/subdomain_middleware.py
@@ -29,8 +29,6 @@ _GLOBAL_PREFIXES = (
     "/static/",
     "/search",
     "/explore",
-    "/activity",
-    "/activity.rss",
     "/people",
     "/shared",
     "/roadmap",
@@ -51,6 +49,11 @@ _GLOBAL_PREFIXES = (
     "/upload",
 )
 
+_GLOBAL_EXACT_PATHS = {
+    "/activity",
+    "/activity.rss",
+}
+
 
 def _should_rewrite(path: str) -> bool:
     if not path.startswith("/"):
@@ -58,6 +61,8 @@ def _should_rewrite(path: str) -> bool:
     # /@<user>/... paths are already canonical — never rewrite, regardless of host.
     # (this lets internal url_for() links keep working on subdomain hosts.)
     if path.startswith("/@"):
+        return False
+    if path in _GLOBAL_EXACT_PATHS:
         return False
     for prefix in _GLOBAL_PREFIXES:
         p = prefix.rstrip("/")

--- a/app/templates/_nav.html
+++ b/app/templates/_nav.html
@@ -6,6 +6,7 @@
   </button>
   <div class="nav-spacer"></div>
   <a href="/explore" class="nav-link nav-hide-narrow">Explore</a>
+  <a href="/activity" class="nav-link nav-hide-mobile">Activity</a>
   <a href="/people" class="nav-link nav-hide-mobile">People</a>
   <a href="/agents" class="nav-link nav-agents nav-hide-mobile">For Agents</a>
   <button
@@ -91,6 +92,7 @@
       </svg>
     </button>
     <a href="/explore" class="nav-mobile-item" role="menuitem">Explore</a>
+    <a href="/activity" class="nav-mobile-item" role="menuitem">Activity</a>
     <a href="/people" class="nav-mobile-item" role="menuitem">People</a>
     <a href="/agents" class="nav-mobile-item" role="menuitem">For Agents</a>
     {% if current_user and current_user.is_authenticated %}

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -46,10 +46,10 @@
 .gactivity-list { display: flex; flex-direction: column; gap: 2px; }
 .gactivity-row {
   display: block; padding: 12px 14px; border: 1px solid var(--border-default);
-  border-radius: var(--radius-md); background: var(--bg-surface); text-decoration: none;
+  border-radius: var(--radius-md); background: var(--bg-surface);
   transition: border-color 0.15s ease;
 }
-.gactivity-row:hover { border-color: var(--border-emphasis); text-decoration: none; }
+.gactivity-row:hover { border-color: var(--border-emphasis); }
 .gactivity-line { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
 .gactivity-verb {
   font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
@@ -57,7 +57,8 @@
 }
 .gactivity-verb.created { color: var(--color-success, #4a9d5a); border: 1px solid var(--color-success, #4a9d5a); }
 .gactivity-verb.updated { color: var(--accent); border: 1px solid var(--accent); }
-.gactivity-title { font-weight: 600; color: var(--text-primary); }
+.gactivity-title { font-weight: 600; color: var(--text-primary); text-decoration: none; }
+.gactivity-title:hover { color: var(--accent); text-decoration: none; }
 .gactivity-meta { margin-top: 4px; font-size: 0.8125rem; color: var(--text-muted); font-family: var(--font-mono); }
 .gactivity-meta a { color: var(--text-secondary); text-decoration: none; }
 .gactivity-meta a:hover { color: var(--accent); }
@@ -161,16 +162,16 @@
   {% if entries %}
   <div class="gactivity-list">
     {% for e in entries %}
-    <a href="{{ e.rel_url }}" class="gactivity-row">
+    <div class="gactivity-row">
       <div class="gactivity-line">
         <span class="gactivity-verb {{ e.event }}">{{ e.event }}</span>
-        <span class="gactivity-title">{{ e.page_title }}</span>
+        <a href="{{ e.rel_url }}" class="gactivity-title">{{ e.page_title }}</a>
       </div>
       <div class="gactivity-meta">
-        in <a href="/@{{ e.owner }}/{{ e.wiki_slug }}" onclick="event.stopPropagation();">{{ e.wiki_title }}</a>
+        in <a href="/@{{ e.owner }}/{{ e.wiki_slug }}">{{ e.wiki_title }}</a>
         &middot; {{ e.relative }}{% if e.author %} &middot; by {{ e.author }}{% endif %}
       </div>
-    </a>
+    </div>
     {% endfor %}
   </div>
 

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Activity - {{ wiki.title or wiki.slug }} - wikihub{% endblock %}
+{% block title %}{% if wiki is defined %}Activity - {{ wiki.title or wiki.slug }} - wikihub{% else %}Activity - wikihub{% endif %}{% endblock %}
 
 {% block extra_css %}
 .activity-shell { display: flex; min-height: calc(100vh - 56px); }
@@ -36,9 +36,44 @@
   .activity-row { grid-template-columns: 30px minmax(0, 1fr); }
   .activity-meta { grid-column: 2; flex-direction: row; align-items: center; justify-content: flex-start; }
 }
+.gactivity-page { max-width: 780px; margin: 0 auto; padding: 32px 16px 64px; }
+@media (min-width: 640px) { .gactivity-page { padding: 48px 24px 64px; } }
+.gactivity-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 6px; }
+.gactivity-page h1 { font-size: 1.75rem; font-weight: 700; letter-spacing: -0.02em; }
+.gactivity-page .subtitle { color: var(--text-secondary); margin-bottom: 28px; font-size: 0.9375rem; }
+.rss-link { display: inline-flex; align-items: center; gap: 6px; color: var(--text-muted); text-decoration: none; font-size: 0.8125rem; }
+.rss-link:hover { color: var(--accent); }
+.gactivity-list { display: flex; flex-direction: column; gap: 2px; }
+.gactivity-row {
+  display: block; padding: 12px 14px; border: 1px solid var(--border-default);
+  border-radius: var(--radius-md); background: var(--bg-surface); text-decoration: none;
+  transition: border-color 0.15s ease;
+}
+.gactivity-row:hover { border-color: var(--border-emphasis); text-decoration: none; }
+.gactivity-line { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.gactivity-verb {
+  font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
+  padding: 1px 6px; border-radius: 3px; flex-shrink: 0;
+}
+.gactivity-verb.created { color: var(--color-success, #4a9d5a); border: 1px solid var(--color-success, #4a9d5a); }
+.gactivity-verb.updated { color: var(--accent); border: 1px solid var(--accent); }
+.gactivity-title { font-weight: 600; color: var(--text-primary); }
+.gactivity-meta { margin-top: 4px; font-size: 0.8125rem; color: var(--text-muted); font-family: var(--font-mono); }
+.gactivity-meta a { color: var(--text-secondary); text-decoration: none; }
+.gactivity-meta a:hover { color: var(--accent); }
+.gactivity-empty { color: var(--text-muted); padding: 40px 0; text-align: center; }
+.pager { display: flex; justify-content: space-between; align-items: center; margin-top: 28px; gap: 12px; }
+.pager a, .pager span {
+  font-size: 0.8125rem; padding: 6px 14px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border-default); text-decoration: none; color: var(--text-secondary);
+}
+.pager a:hover { border-color: var(--border-emphasis); color: var(--accent); }
+.pager .disabled { opacity: 0.35; }
+.pager .page-num { border: none; color: var(--text-muted); }
 {% endblock %}
 
 {% block body %}
+{% if wiki is defined %}
 <div class="activity-shell">
   <aside class="sidebar">
     <div class="sidebar-section">
@@ -112,4 +147,49 @@
     </div>
   </main>
 </div>
+{% else %}
+<div class="gactivity-page">
+  <div class="gactivity-head">
+    <h1>Activity</h1>
+    <a href="{{ rss_url }}" class="rss-link" title="RSS feed">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg>
+      RSS
+    </a>
+  </div>
+  <div class="subtitle">Recent page creations and updates across public wikis.</div>
+
+  {% if entries %}
+  <div class="gactivity-list">
+    {% for e in entries %}
+    <a href="{{ e.rel_url }}" class="gactivity-row">
+      <div class="gactivity-line">
+        <span class="gactivity-verb {{ e.event }}">{{ e.event }}</span>
+        <span class="gactivity-title">{{ e.page_title }}</span>
+      </div>
+      <div class="gactivity-meta">
+        in <a href="/@{{ e.owner }}/{{ e.wiki_slug }}" onclick="event.stopPropagation();">{{ e.wiki_title }}</a>
+        &middot; {{ e.relative }}{% if e.author %} &middot; by {{ e.author }}{% endif %}
+      </div>
+    </a>
+    {% endfor %}
+  </div>
+
+  <div class="pager">
+    {% if pagination.has_prev %}
+      <a href="/activity?page={{ pagination.prev_num }}">&larr; Newer</a>
+    {% else %}
+      <span class="disabled">&larr; Newer</span>
+    {% endif %}
+    <span class="page-num">Page {{ pagination.page }} of {{ pagination.pages or 1 }}</span>
+    {% if pagination.has_next %}
+      <a href="/activity?page={{ pagination.next_num }}">Older &rarr;</a>
+    {% else %}
+      <span class="disabled">Older &rarr;</span>
+    {% endif %}
+  </div>
+  {% else %}
+  <div class="gactivity-empty">No public activity yet.</div>
+  {% endif %}
+</div>
+{% endif %}
 {% endblock %}

--- a/app/templates/agents.html
+++ b/app/templates/agents.html
@@ -123,7 +123,7 @@ curl -X POST {{ request.host_url }}api/v1/auth/magic-link \
   -H 'Authorization: Bearer wh_...' \
   -H 'Content-Type: application/json' \
   -d '{"path":"wiki/hello.md","content":"# Hello\n\nMy first page.","visibility":"public"}'</pre></div>
-  <p>Page <code>visibility</code> values are <code>public</code>, <code>public-edit</code>, <code>private</code>, <code>unlisted</code>, and <code>unlisted-edit</code>. If omitted, the page inherits from <code>.wikihub/acl</code>; ACL-only <code>public-view</code> and <code>unlisted-view</code> directives are stored and reported as <code>public</code> and <code>unlisted</code> page visibility. Set frontmatter <code>pinned: true</code> to float a readable page to the top of the wiki sidebar; pinning never overrides read permissions.</p>
+  <p>Page <code>visibility</code> values are <code>public</code>, <code>public-edit</code>, <code>private</code>, <code>unlisted</code>, and <code>unlisted-edit</code>. If omitted, the page inherits from <code>.wikihub/acl</code>; ACL-only <code>public-view</code> and <code>unlisted-view</code> directives are stored and reported as <code>public</code> and <code>unlisted</code> page visibility. Unlisted pages are readable by direct URL and appear in that wiki's own navigation and RSS feed for viewers who can read them, but stay out of global search, explore, activity, RSS, and profile listings. Set frontmatter <code>pinned: true</code> to float a readable page to the top of the wiki sidebar; pinning never overrides read permissions.</p>
 
   <h2>Poll page metadata</h2>
   <div class="code-block"><pre>curl -X GET {{ request.host_url }}api/v1/wikis/myagent/research/pages/wiki/hello.md?meta=1 \
@@ -226,6 +226,9 @@ wikihub mcp-config                # prints mcpServers JSON pre-filled</pre></div
   <ul>
     <li><code>/llms.txt</code> — site-wide index</li>
     <li><code>/llms-full.txt</code> — all public pages</li>
+    <li><code>/activity</code> — recent public page creations and updates</li>
+    <li><code>/activity.rss</code> — RSS for recent public page activity</li>
+    <li><code>/@user/wiki/activity.rss</code> — RSS for pages readable in that wiki, including unlisted pages reachable by link</li>
     <li><code>/.well-known/mcp/server-card.json</code> — MCP server card</li>
     <li><code>/.well-known/mcp</code> — MCP discovery</li>
     <li><code>/.well-known/wikihub.json</code> — bootstrap manifest</li>

--- a/app/templates/explore.html
+++ b/app/templates/explore.html
@@ -74,7 +74,10 @@
 
 {% block body %}
 <div class="explore-page">
-  <h1>Explore</h1>
+  <div class="section-header" style="margin-bottom:8px;">
+    <h1>Explore</h1>
+    <a href="/activity" class="section-link">Activity feed &rarr;</a>
+  </div>
   <p class="subtitle">Discover public wikis, sorted by what has been updated most recently, and the people who publish them.</p>
 
   {% if editorial %}

--- a/app/templates/folder.html
+++ b/app/templates/folder.html
@@ -175,6 +175,11 @@
 
     <div class="folder-header">
       <div class="folder-title">{{ folder_path or wiki.title or wiki.slug }}</div>
+      {% if folder_path == 'history' %}
+      <a href="/@{{ owner.username }}/{{ wiki.slug }}/activity.rss" title="Subscribe via RSS" style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;color:var(--text-muted);border-radius:var(--radius-sm);text-decoration:none;">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg>
+      </a>
+      {% endif %}
       <div class="download-menu" style="position:relative;display:inline-flex;">
         <button style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;color:var(--text-muted);border:none;background:transparent;cursor:pointer;border-radius:var(--radius-sm);" title="Download / Clone">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>

--- a/cli/README.md
+++ b/cli/README.md
@@ -61,8 +61,9 @@ wikihub search "hello" --wiki you/notes
 When omitted, page visibility inherits from `.wikihub/acl`; ACL-only
 `public-view` and `unlisted-view` directives are returned as page-level
 `public` and `unlisted`. Unlisted pages are readable by direct URL and appear
-in that wiki's own navigation/sidebar for viewers who can read them, but remain
-excluded from discovery surfaces such as search, explore, and profiles.
+in that wiki's own navigation/sidebar and per-wiki RSS feed for viewers who can
+read them, but remain excluded from global discovery surfaces such as search,
+explore, global activity, global RSS, and profiles.
 To pin a page in the wiki sidebar, include `pinned: true` in the page
 frontmatter and write or publish the full markdown file again. Pinning only
 affects readable pages; it does not grant access.

--- a/deploy/static/welcome.html
+++ b/deploy/static/welcome.html
@@ -169,7 +169,7 @@ ul li { margin-bottom: 6px; }
     <h2>For agents &amp; crawlers</h2>
     <p>If you're an AI agent or search crawler, welcome — WikiHub is built for you. A few notes so we can keep the lights on:</p>
     <ul>
-      <li><strong>Use the structured surfaces.</strong> Plain markdown is at <code>/&lt;path&gt;.md</code>. The site index is at <a href="/llms.txt"><code>/llms.txt</code></a>. Agent-setup docs at <a href="/AGENTS.md"><code>/AGENTS.md</code></a>. JSON listing of public wikis at <a href="/api/v1/wikis"><code>/api/v1/wikis</code></a>.</li>
+      <li><strong>Use the structured surfaces.</strong> Plain markdown is at <code>/&lt;path&gt;.md</code>. The site index is at <a href="/llms.txt"><code>/llms.txt</code></a>. Recent public changes are at <a href="/activity"><code>/activity</code></a> and <a href="/activity.rss"><code>/activity.rss</code></a>. Agent-setup docs are at <a href="/AGENTS.md"><code>/AGENTS.md</code></a>. JSON listing of public wikis is at <a href="/api/v1/wikis"><code>/api/v1/wikis</code></a>.</li>
       <li><strong>Skip <code>/history</code> and <code>/commit/&lt;sha&gt;</code> on a hot loop.</strong> They run a git log per request and are blocked for known AI/SEO bots. Cache <code>/commit/&lt;sha&gt;</code> aggressively — it's immutable.</li>
       <li><strong>Polite crawl rate is &lt;= 60 req/min</strong> overall. Crawl regular pages first; revisit history only when your index says the page changed.</li>
       <li><strong>Want priority / partner access?</strong> Programmatically POST to <a href="/api/v1/feedback"><code>/api/v1/feedback</code></a> with <code>{"kind":"comment","subject":"crawler intro","body":"...", "contact_email":"..."}</code> — we read these. Or have a human on your team fill the form above.</li>

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3828,6 +3828,11 @@ def test_subdomain_routing(client):
     r = client.get("/intro", headers={"Host": "recipes.wikihub.md"})
     assert r.status_code == 200, f"wiki subdomain page failed: {r.status_code}"
 
+    r = client.post("/api/v1/wikis/subowner/cookbook/pages",
+                    json={"path": "activity/menu.md", "content": "# Activity Menu\nWeekly prep.",
+                          "visibility": "public", "message": "add activity page"}, headers=h)
+    assert r.status_code in (200, 201)
+
     # Apex /@user/<slug> 301s to wiki subdomain
     r = client.get("/@subowner/cookbook",
                    headers={"Host": "wikihub.md"}, follow_redirects=False)
@@ -3855,6 +3860,11 @@ def test_subdomain_routing(client):
         assert r.mimetype == "application/rss+xml"
         assert b"WikiHub" in r.data
         assert b"recent activity" in r.data
+
+    r = client.get("/activity/menu", headers={"Host": "recipes.wikihub.md"})
+    assert r.status_code == 200, f"/activity/<page> should rewrite to wiki page on wiki subdomain: {r.status_code}"
+    assert b"Activity Menu" in r.data
+    assert b"Recent page creations and updates across public wikis" not in r.data
 
     # Internal url_for()-generated links use the full /@user/slug/page form.
     # On a wiki subdomain, those must resolve — either directly or 301 to the

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -6622,6 +6622,9 @@ def run_all():
             ("nav header nowrap at narrow widths (wikihub-gnat)", lambda: test_nav_header_nowrap(client)),
             ("per-user wiki limit + 429 (wikihub-20ct)", lambda: test_wiki_limit_effective_resolution_and_429(client, app)),
             ("set_wiki_limit imports from app root (wikihub-20ct)", lambda: test_set_wiki_limit_script_imports_from_repo_root()),
+            ("global activity excludes non-public content", lambda: test_global_activity_excludes_non_public(client, key)),
+            ("activity RSS well-formed + correct links (both hosts)", lambda: test_activity_rss_is_well_formed_with_correct_links(client, key)),
+            ("global activity pagination", lambda: test_activity_pagination(client, key)),
         ]
 
         passed = 1  # account creation already passed
@@ -6647,6 +6650,133 @@ def run_all():
 
     teardown()
     return 1 if failed else 0
+
+
+def _seed_activity_fixtures(client, key):
+    """Create a public wiki + an unlisted wiki that also holds a private page.
+
+    Returns the header dict. Used by the activity-feed tests below.
+    """
+    h = {"Authorization": f"Bearer {key}"}
+    # public wiki with a public page
+    client.post("/api/v1/wikis", json={"slug": "pubwiki", "title": "Public Wiki"}, headers=h)
+    client.post("/api/v1/wikis/agent1/pubwiki/pages", json={
+        "path": "wiki/public-note.md",
+        "content": "---\ntitle: Public Note\nvisibility: public\n---\n\n# Public Note\n",
+        "visibility": "public",
+    }, headers=h)
+    # unlisted wiki: one unlisted page (reachable by link) + one private page (secret)
+    client.post("/api/v1/wikis", json={"slug": "secretwiki", "title": "Secret Wiki"}, headers=h)
+    client.post("/api/v1/wikis/agent1/secretwiki/pages", json={
+        "path": "wiki/unlisted-note.md",
+        "content": "---\ntitle: Unlisted Note\nvisibility: unlisted\n---\n\n# Unlisted Note\n",
+        "visibility": "unlisted",
+    }, headers=h)
+    client.post("/api/v1/wikis/agent1/secretwiki/pages", json={
+        "path": "wiki/private-note.md",
+        "content": "---\ntitle: Private Note\nvisibility: private\n---\n\n# Private Note\n",
+        "visibility": "private",
+    }, headers=h)
+    return h
+
+
+def test_global_activity_excludes_non_public(client, key):
+    """Global /activity page + /activity.rss show public pages only; unlisted and
+    private never leak into the site-wide surface."""
+    _seed_activity_fixtures(client, key)
+
+    # HTML page (anonymous request)
+    r = client.get("/activity")
+    assert r.status_code == 200, f"/activity should render, got {r.status_code}"
+    body = r.get_data(as_text=True)
+    assert "Public Note" in body, "public page must appear in global activity"
+    assert "Unlisted Note" not in body, "unlisted page must NOT appear in global activity"
+    assert "Private Note" not in body, "private page must NOT appear in global activity"
+
+    # RSS feed (anonymous request)
+    r = client.get("/activity.rss")
+    assert r.status_code == 200
+    assert r.mimetype == "application/rss+xml", f"unexpected mimetype {r.mimetype}"
+    rss = r.get_data(as_text=True)
+    assert "Public Note" in rss
+    assert "Unlisted Note" not in rss
+    assert "Private Note" not in rss
+
+
+def test_activity_rss_is_well_formed_with_correct_links(client, key):
+    """Both the global and per-wiki RSS feeds parse as XML and carry absolute
+    links matching the request host (tested for two host forms)."""
+    from xml.etree import ElementTree
+
+    _seed_activity_fixtures(client, key)
+    # flask_login caches current_user on `g`, which persists across requests
+    # inside this harness's wrapping app_context(). Clear it AND use a fresh
+    # cookieless client so "anonymous" surfaces are checked as a true anon
+    # request (else the owner would see their own private pages). Same idiom as
+    # test_me_capabilities.
+    from flask import g as _flask_g
+    _flask_g.pop("_login_user", None)
+    anon = client.application.test_client()
+
+    # two host forms to prove absolute links track the request host. Avoid the
+    # production apex (wikihub.md), which triggers canonical-redirect middleware
+    # on /@owner/slug paths — irrelevant to feed-link correctness.
+    for host in ("localhost", "example.test"):
+        # global feed
+        r = anon.get("/activity.rss", headers={"Host": host})
+        assert r.status_code == 200
+        root = ElementTree.fromstring(r.get_data())  # raises on malformed XML
+        assert root.tag == "rss"
+        channel = root.find("channel")
+        assert channel is not None
+        items = channel.findall("item")
+        assert items, "global RSS should have at least one item"
+        # global feed carries only public pages; the private note never leaks
+        all_links = " ".join(it.find("link").text for it in items)
+        assert "/@agent1/pubwiki/" in all_links, f"public page missing from global RSS: {all_links[:200]}"
+        assert "secretwiki" not in all_links, "unlisted/private wiki must not leak into global RSS"
+        self_link = channel.find("{http://www.w3.org/2005/Atom}link")
+        assert self_link is not None and host in self_link.get("href")
+
+        # per-wiki feed for the unlisted wiki (anonymous request)
+        r = anon.get("/@agent1/secretwiki/activity.rss", headers={"Host": host})
+        assert r.status_code == 200
+        assert r.mimetype == "application/rss+xml"
+        root = ElementTree.fromstring(r.get_data())
+        titles = [it.find("title").text for it in root.find("channel").findall("item")]
+        joined = " ".join(titles)
+        # unlisted pages are reachable-by-link, so they belong in the wiki feed…
+        assert "Unlisted Note" in joined, "unlisted page should appear in per-wiki RSS"
+        # …but private pages must never appear for an anonymous request
+        assert "Private Note" not in joined, f"private page must NOT appear in anon per-wiki RSS; got titles={titles!r}"
+        for it in root.find("channel").findall("item"):
+            assert it.find("link").text.startswith(f"http://{host}/@agent1/secretwiki/")
+
+
+def test_activity_pagination(client, key):
+    """Global activity paginates; page 2 shows different entries than page 1."""
+    h = {"Authorization": f"Bearer {key}"}
+    client.post("/api/v1/wikis", json={"slug": "pagewiki", "title": "Page Wiki"}, headers=h)
+    # create > one page of activity (per_page=40)
+    for i in range(45):
+        client.post("/api/v1/wikis/agent1/pagewiki/pages", json={
+            "path": f"wiki/note-{i:03d}.md",
+            "content": f"---\ntitle: Note {i:03d}\nvisibility: public\n---\n\n# Note {i:03d}\n",
+            "visibility": "public",
+        }, headers=h)
+
+    r1 = client.get("/activity?page=1")
+    assert r1.status_code == 200
+    b1 = r1.get_data(as_text=True)
+    assert "Page 1 of" in b1
+    assert "Older" in b1  # has_next → link present
+
+    r2 = client.get("/activity?page=2")
+    assert r2.status_code == 200
+    b2 = r2.get_data(as_text=True)
+    assert "Page 2 of" in b2
+    # the two pages should not be identical (different slice of entries)
+    assert b1 != b2, "page 2 should differ from page 1"
 
 
 if __name__ == "__main__":

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3901,6 +3901,11 @@ def test_subdomain_routing(client):
     assert b"cookbook" in r.data
     assert b"WikiHub" not in r.data
 
+    r = client.get("/@subowner/cookbook/activity/menu",
+                   headers={"Host": "wikihub.md"}, follow_redirects=False)
+    assert r.status_code == 301, f"activity folder page on apex should canonicalize to wiki subdomain: {r.status_code}"
+    assert "recipes.wikihub.md/activity/menu" in r.headers["Location"]
+
     # Same regression check for user subdomain
     r = client.get("/@subowner/cookbook/intro",
                    headers={"Host": "subowner.wikihub.md"}, follow_redirects=False)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -29,7 +29,7 @@ os.environ["SESSION_COOKIE_SECURE"] = "0"
 
 from app import create_app, db
 from app.auth_utils import _ip_write_timestamps, _write_timestamps
-from app.models import User, utcnow
+from app.models import Page, User, Wiki, utcnow
 
 
 def setup():
@@ -6624,6 +6624,8 @@ def run_all():
             ("set_wiki_limit imports from app root (wikihub-20ct)", lambda: test_set_wiki_limit_script_imports_from_repo_root()),
             ("global activity excludes non-public content", lambda: test_global_activity_excludes_non_public(client, key)),
             ("activity RSS well-formed + correct links (both hosts)", lambda: test_activity_rss_is_well_formed_with_correct_links(client, key)),
+            ("per-wiki RSS finds older unlisted pages after private pages", lambda: test_wiki_activity_rss_keeps_older_unlisted_after_private_pages(client, key)),
+            ("global activity rows avoid nested anchors", lambda: test_global_activity_rows_do_not_nest_anchors(client, key)),
             ("global activity pagination", lambda: test_activity_pagination(client, key)),
         ]
 
@@ -6751,6 +6753,96 @@ def test_activity_rss_is_well_formed_with_correct_links(client, key):
         assert "Private Note" not in joined, f"private page must NOT appear in anon per-wiki RSS; got titles={titles!r}"
         for it in root.find("channel").findall("item"):
             assert it.find("link").text.startswith(f"http://{host}/@agent1/secretwiki/")
+
+
+def test_wiki_activity_rss_keeps_older_unlisted_after_private_pages(client, key):
+    """Anonymous per-wiki RSS keeps reachable unlisted pages even when newer
+    private pages would otherwise fill the candidate window."""
+    from datetime import timedelta
+    from flask import g as _flask_g
+    from xml.etree import ElementTree
+
+    h = {"Authorization": f"Bearer {key}"}
+    client.post("/api/v1/wikis", json={"slug": "rss-sparse", "title": "RSS Sparse"}, headers=h)
+    client.post("/api/v1/wikis/agent1/rss-sparse/pages", json={
+        "path": "wiki/older-unlisted.md",
+        "content": "---\ntitle: Older Unlisted\nvisibility: unlisted\n---\n\n# Older Unlisted\n",
+        "visibility": "unlisted",
+    }, headers=h)
+
+    owner = User.query.filter_by(username="agent1").first()
+    wiki = Wiki.query.filter_by(owner_id=owner.id, slug="rss-sparse").first()
+    base = utcnow()
+    visible_page = Page.query.filter_by(wiki_id=wiki.id, path="wiki/older-unlisted.md").first()
+    visible_page.updated_at = base
+    visible_page.created_at = base
+    for i in range(305):
+        db.session.add(Page(
+            wiki_id=wiki.id,
+            path=f"secrets/private-{i:03d}.md",
+            title=f"Private {i:03d}",
+            visibility="private",
+            created_at=base + timedelta(seconds=i + 1),
+            updated_at=base + timedelta(seconds=i + 1),
+        ))
+    db.session.commit()
+
+    _flask_g.pop("_login_user", None)
+    anon = client.application.test_client()
+    r = anon.get("/@agent1/rss-sparse/activity.rss")
+    assert r.status_code == 200
+    titles = [
+        it.find("title").text
+        for it in ElementTree.fromstring(r.get_data()).find("channel").findall("item")
+    ]
+    joined = " ".join(titles)
+    assert "Older Unlisted" in joined, f"older readable page missing from RSS: {titles!r}"
+    assert "Private 304" not in joined, "anonymous RSS must not expose private pages"
+
+
+def test_global_activity_rows_do_not_nest_anchors(client, key):
+    """Global activity rows render page and wiki links as sibling anchors."""
+    from html.parser import HTMLParser
+
+    _seed_activity_fixtures(client, key)
+    r = client.get("/activity")
+    assert r.status_code == 200
+
+    class AnchorNestingParser(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.anchor_depth = 0
+            self.nested = False
+            self.row_count = 0
+            self.page_links = 0
+            self.wiki_links = 0
+
+        def handle_starttag(self, tag, attrs):
+            attrs = dict(attrs)
+            classes = attrs.get("class", "").split()
+            href = attrs.get("href", "")
+            if "gactivity-row" in classes:
+                self.row_count += 1
+                assert tag != "a", "global activity row must not be an anchor"
+            if tag == "a":
+                if self.anchor_depth:
+                    self.nested = True
+                self.anchor_depth += 1
+                if "gactivity-title" in classes:
+                    self.page_links += 1
+                if href.startswith("/@agent1/pubwiki"):
+                    self.wiki_links += 1
+
+        def handle_endtag(self, tag):
+            if tag == "a":
+                self.anchor_depth -= 1
+
+    parser = AnchorNestingParser()
+    parser.feed(r.get_data(as_text=True))
+    assert parser.row_count > 0, "expected global activity rows"
+    assert parser.page_links > 0, "page title should remain a primary link"
+    assert parser.wiki_links > 0, "wiki link should remain present"
+    assert not parser.nested, "global activity must not contain nested anchors"
 
 
 def test_activity_pagination(client, key):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3846,6 +3846,16 @@ def test_subdomain_routing(client):
     # rewritten into /@subowner/api/v1/ping (which would 404 differently)
     assert r.status_code in (404, 200)
 
+    for host in ("subowner.wikihub.md", "recipes.wikihub.md"):
+        r = client.get("/activity", headers={"Host": host})
+        assert r.status_code == 200, f"/activity should stay global on {host}: {r.status_code}"
+        assert b"Recent page creations and updates across public wikis" in r.data
+        r = client.get("/activity.rss", headers={"Host": host})
+        assert r.status_code == 200, f"/activity.rss should stay global on {host}: {r.status_code}"
+        assert r.mimetype == "application/rss+xml"
+        assert b"WikiHub" in r.data
+        assert b"recent activity" in r.data
+
     # Internal url_for()-generated links use the full /@user/slug/page form.
     # On a wiki subdomain, those must resolve — either directly or 301 to the
     # short form on the same host. Regression test for the double-prefix bug.

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -3865,6 +3865,32 @@ def test_subdomain_routing(client):
     if r.status_code == 301:
         assert "recipes.wikihub.md/intro" in r.headers["Location"]
 
+    r = client.get("/@subowner/cookbook/activity",
+                   headers={"Host": "recipes.wikihub.md"}, follow_redirects=False)
+    assert r.status_code == 200, f"per-wiki activity on wiki subdomain should not redirect: {r.status_code}"
+    assert b"Recent visible edits" in r.data
+    assert b"Recent page creations and updates across public wikis" not in r.data
+
+    r = client.get("/@subowner/cookbook/activity",
+                   headers={"Host": "wikihub.md"}, follow_redirects=False)
+    assert r.status_code == 200, f"per-wiki activity on apex should not canonicalize to global activity: {r.status_code}"
+    assert b"Recent visible edits" in r.data
+    assert b"Recent page creations and updates across public wikis" not in r.data
+
+    r = client.get("/@subowner/cookbook/activity.rss",
+                   headers={"Host": "recipes.wikihub.md"}, follow_redirects=False)
+    assert r.status_code == 200, f"per-wiki RSS on wiki subdomain should not redirect: {r.status_code}"
+    assert r.mimetype == "application/rss+xml"
+    assert b"cookbook" in r.data
+    assert b"WikiHub" not in r.data
+
+    r = client.get("/@subowner/cookbook/activity.rss",
+                   headers={"Host": "wikihub.md"}, follow_redirects=False)
+    assert r.status_code == 200, f"per-wiki RSS on apex should not canonicalize to global RSS: {r.status_code}"
+    assert r.mimetype == "application/rss+xml"
+    assert b"cookbook" in r.data
+    assert b"WikiHub" not in r.data
+
     # Same regression check for user subdomain
     r = client.get("/@subowner/cookbook/intro",
                    headers={"Host": "subowner.wikihub.md"}, follow_redirects=False)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -6624,6 +6624,7 @@ def run_all():
             ("set_wiki_limit imports from app root (wikihub-20ct)", lambda: test_set_wiki_limit_script_imports_from_repo_root()),
             ("global activity excludes non-public content", lambda: test_global_activity_excludes_non_public(client, key)),
             ("activity RSS well-formed + correct links (both hosts)", lambda: test_activity_rss_is_well_formed_with_correct_links(client, key)),
+            ("private-only wiki RSS does not leak metadata", lambda: test_wiki_activity_rss_private_only_wiki_does_not_leak_metadata(client, key)),
             ("per-wiki RSS finds older unlisted pages after private pages", lambda: test_wiki_activity_rss_keeps_older_unlisted_after_private_pages(client, key)),
             ("global activity rows avoid nested anchors", lambda: test_global_activity_rows_do_not_nest_anchors(client, key)),
             ("global activity pagination", lambda: test_activity_pagination(client, key)),
@@ -6753,6 +6754,27 @@ def test_activity_rss_is_well_formed_with_correct_links(client, key):
         assert "Private Note" not in joined, f"private page must NOT appear in anon per-wiki RSS; got titles={titles!r}"
         for it in root.find("channel").findall("item"):
             assert it.find("link").text.startswith(f"http://{host}/@agent1/secretwiki/")
+
+
+def test_wiki_activity_rss_private_only_wiki_does_not_leak_metadata(client, key):
+    h = {"Authorization": f"Bearer {key}"}
+    client.post("/api/v1/wikis", json={"slug": "private-rss", "title": "Private RSS"}, headers=h)
+    client.post("/api/v1/wikis/agent1/private-rss/pages", json={
+        "path": "wiki/private-only.md",
+        "content": "---\ntitle: Private Only\nvisibility: private\n---\n\n# Private Only\n",
+        "visibility": "private",
+    }, headers=h)
+
+    from flask import g as _flask_g
+    _flask_g.pop("_login_user", None)
+    anon = client.application.test_client()
+
+    r = anon.get("/@agent1/private-rss/activity.rss")
+    assert r.status_code == 401
+    body = r.get_data(as_text=True)
+    assert "Private RSS" not in body
+    assert "Private Only" not in body
+    assert r.mimetype != "application/rss+xml"
 
 
 def test_wiki_activity_rss_keeps_older_unlisted_after_private_pages(client, key):


### PR DESCRIPTION
## Intent

Build activity feeds for WikiHub. (1) A site-wide global /activity page listing recent page creations/updates across PUBLIC wikis only, paginated, linked from /explore and the header nav. Strict no-leak requirement: unlisted/private/public-edit-private pages must never appear in any global surface, enforced at the QUERY level (not post-render) by reusing the canonical DISCOVERABLE_VISIBILITIES filter. (2) RSS: /activity.rss for the global public feed, and per-wiki /@owner/slug/activity.rss. Per-wiki RSS deliberately respects reachable-by-link visibility: it INCLUDES unlisted pages (same semantics as the pages themselves being reachable at their URLs) but private pages must never appear for anonymous requests — enforced by reusing the canonical _viewer_can_read_page/can_read helpers. (3) Added an RSS link icon to the existing per-wiki history page. (4) New app/feeds.py holds pure formatting shared by all surfaces (activity_entry, render_rss, relative_time). Tests added to tests/test_e2e.py cover: global feed excludes an unlisted+private fixture, RSS is well-formed XML with correct absolute links across two host forms, and pagination. Note on test choices that may look surprising in the diff: the per-wiki RSS visibility test uses a fresh cookieless client AND pops flask-login's g._login_user because this test harness runs all tests inside one app_context() so current_user leaks across requests (same idiom as test_me_capabilities); and it uses 'example.test' rather than the production apex 'wikihub.md' as the second host because wikihub.md triggers canonical-redirect middleware on /@owner/slug paths, which is unrelated to feed-link correctness.

## What Changed

- Added site-wide activity surfaces at `/activity` and `/activity.rss`, with navigation/docs updates and discoverable-only visibility filtering for global feeds.
- Added shared activity/RSS formatting helpers plus per-wiki `/@owner/slug/activity.rss` feeds that include link-reachable unlisted pages while excluding private content for anonymous readers.
- Added end-to-end coverage for activity visibility, RSS links/XML, pagination, and subdomain/canonical routing behavior.

## Risk Assessment

✅ Low: The change is well-bounded to activity/feed rendering, route registration, and routing exceptions, with prior visibility and canonical-routing regressions now covered by targeted code paths and tests.

## Testing

After fixing local setup with an isolated venv and throwaway Postgres, I ran the full e2e suite successfully, then manually seeded public/unlisted/private pages and captured rendered UI plus RSS evidence showing global public-only behavior, per-wiki unlisted RSS inclusion, private non-leakage, Explore/header activity links, and the per-wiki history RSS affordance.

- Evidence: Global /activity rendered page showing only the public page and RSS link (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXSP1VR7G2BV25H0QWSHH0SZ/global-activity.png</code>)
- Evidence: /explore rendered with Activity nav/link and public wiki only (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXSP1VR7G2BV25H0QWSHH0SZ/explore-activity-link.png</code>)
- Evidence: Per-wiki history page showing Subscribe via RSS icon/link (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXSP1VR7G2BV25H0QWSHH0SZ/wiki-history-rss-link.png</code>)
<details>
<summary>Evidence: Captured global activity HTML</summary>

```text
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="UTF-8">
<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
<title>Activity - wikihub</title>
<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
<link rel="manifest" href="/static/manifest.json">

<!-- PWA / iOS Add-to-Home-Screen polish -->
<meta name="apple-mobile-web-app-capable" content="yes">
<meta name="mobile-web-app-capable" content="yes">
<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
<meta name="apple-mobile-web-app-title" content="wikihub">
<meta name="application-name" content="wikihub">
<meta name="theme-color" content="#0f0e0c" media="(prefers-color-scheme: dark)">
<meta name="theme-color" content="#faf7f1" media="(prefers-color-scheme: light)">
<link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon-180.png">
<link rel="apple-touch-icon" href="/static/favicon.svg">
<!-- agent discovery: point AI agents at plain-markdown + LLM index. wikihub-5764 -->
<link rel="alternate" type="text/markdown" href="/AGENTS.md" title="Agent setup (markdown)">
<link rel="alternate" type="text/plain" href="/llms.txt" title="LLM index">
<meta property="og:title" content="Activity - wikihub">
<meta property="og:description" content="GitHub for LLM wikis. Publish markdown knowledge bases in seconds.">
<meta property="og:type" content="website">
<meta property="og:site_name" content="wikihub">
<meta name="description" content="GitHub for LLM wikis. Publish markdown knowledge bases in seconds.">

<meta name="theme-color" content="#0f0e0c" media="(prefers-color-scheme: dark)">
<meta name="theme-color" content="#faf7f1" media="(prefers-color-scheme: light)">
<script>(function(){try{var t=localStorage.getItem('wikihubTheme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
<style>
/* ───────── THEME TOKENS — dark default ───────── */
:root {
  color-scheme: dark;

  /* surfaces — obsidian warm */
  --bg-base: #0f0e0c;
  --bg-surface: #191714;
  --bg-elevated: #221f1b;
  --bg-overlay: #2a2622;

  /* text — warm ink */
  --text-primary: #e8e0d4;
  --text-secondary: #b8ad9e;
  --text-tertiary: #887d6e;
  --text-muted: #5a5248;
  --text-on-accent: #0f0e0c;

  /* accent — amber/gold */
  --accent: #d4a04a;
  --accent-hover: #e0b35a;
  --accent-muted: rgba(212, 160, 74, 0.12);
  --accent-subtle: rgba(212, 160, 74, 0.06);
  --accent-glow: rgba(212, 160, 74, 0.22);

  /* semantic */
  --color-public: #7a9e6b;
  --color-private: #c45c3c;
  --color-unlisted: #b8ad9e;
  --color-edit: #d4a04a;
  --color-wikilink: #d4a04a;
  --color-wikilink-broken: #c45c3c;
  --color-external: #7a9bb5;
  --color-success: #7a9e6b;
  --color-warning: #d4a04a;
  --color-error: #c45c3c;
  --color-error-soft: #d88c75;

  /* tinted rgba triplets for inline rgba(x,x,x, alpha) use */
  --rgb-public: 122, 158, 107;
  --rgb-private: 196, 92, 60;
  --rgb-accent: 212, 160, 74;

  /* borders — warm tinted */
  --border-default: rgba(200, 180, 150, 0.08);
  --border-emphasis: rgba(200, 180, 150, 0.15);
  --border-strong: rgba(200, 180, 150, 0.25);
  --border-accent: rgba(212, 160, 74, 0.4);

  /* controls */
  --control-bg: rgba(0, 0, 0, 0.2);
  --control-bg-hover: rgba(200, 180, 150, 0.08);
  --control-border: rgba(200, 180, 150, 0.12);
  --search-trigger-bg: #1a1816;
  --menu-bg: rgba(25, 23, 20, 0.98);
  --scrim: rgba(0, 0, 0, 0.7);
  --scrim-soft: rgba(0, 0, 0, 0.4);
  --shadow-color: rgba(0, 0, 0, 0.35);
  --hover-preview-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
  --card-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);

  /* gradients (derived from tokens; light mode will re-point these) */
  --gradient-person-card: linear-gradient(180deg, rgba(212, 160, 74, 0.08), rgba(25, 23, 20, 0.95));
  --gradient-person-avatar: linear-gradient(135deg, rgba(212, 160, 74, 0.18), rgba(34, 31, 27, 1));
  --gradient-subtle-tint: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.01));

  /* typography */
  --font-body: 'Inter', -apple-system, sans-serif;
  --font-mono: 'IBM Plex Mono', 'Menlo', monospace;

  /* radius */
  --radius-sm: 4px;
  --radius-md: 6px;
  --radius-lg: 10px;
}

/* ───────── LIGHT PALETTE — warm paper under a desk lamp ───────── */
@media (prefers-color-scheme: light) {
  :root {
    color-scheme: light;

    /* warm paper under a desk lamp:
       base is the lit desk surface, surfaces sit above with real elevation
       (darker), not lighter — same direction as paper stacks catching shadow.
       Accent is amber (not bronze); shadows are warm, not gray. */
    --bg-base: #fbf5e8;       /* lit paper */
    --bg-surface: #f4e9d4;    /* card on the desk */
    --bg-elevated: #eddcbf;   /* lifted like a notebook */
    --bg-overlay: #e5d0a8;    /* overlay / popover */

    --text-primary: #2a1d0e;  /* warm sepia ink */
    --text-secondary: #574532;
    --text-tertiary: #7d6a4f;
    --text-muted: #a59070;
    --text-on-accent: #1a0f03;

    /* brand amber — richer than my first pass, still passes AA as link text */
    --accent: #a86212;
    --accent-hover: #c87918;
    --accent-muted: rgba(168, 98, 18, 0.15);
    --accent-subtle: rgba(168, 98, 18, 0.08);
    --accent-glow: rgba(212, 160, 74, 0.35);   /* lamp-glow focus ring */

    --color-public: #4a7a41;
    --color-private: #9a3e23;
    --color-unlisted: #7d6a4f;
    --color-edit: #a86212;
    --color-wikilink: #a86212;
    --color-wikilink-broken: #9a3e23;
    --color-external: #395a78;
    --color-success: #4a7a41;
    --color-warning: #a86212;
    --color-error: #9a3e23;
    --color-error-soft: #b25640;

    --rgb-public: 74, 122, 65;
    --rgb-private: 154, 62, 35;
    --rgb-accent: 168, 98, 18;

    /* borders tinted warm sepia */
    --border-default: rgba(90, 58, 18, 0.12);
    --border-emphasis: rgba(90, 58, 18, 0.22);
    --border-strong: rgba(90, 58, 18, 0.34);
    --border-accent: rgba(168, 98, 18, 0.50);

    --control-bg: rgba(255, 248, 230, 0.7);
    --control-bg-hover: rgba(90, 58, 18, 0.07);
    --control-border: rgba(90, 58, 18, 0.18);
    --search-trigger-bg: #eee0c6;
    --menu-bg: rgba(251, 245, 232, 0.98);
    --scrim: rgba(40, 25, 10, 0.40);
    --scrim-soft: rgba(40, 25, 10, 0.22);

    /* warm amber-tinted shadows — "desk lamp spill", not neutral gray */
    --shadow-color: rgba(90, 58, 18, 0.14);
    --hover-preview-shadow: 0 8px 28px rgba(90, 58, 18, 0.18);
    --card-shadow: 0 1px 2px rgba(90, 58, 18, 0.12);

    /* light-mode gradients — paper warmth, amber glow, no dark endpoints */
    --gradient-person-card: linear-gradient(180deg, rgba(212, 160, 74, 0.14), rgba(244, 233, 212, 1));
    --gradient-person-avatar: linear-gradient(135deg, rgba(212, 160, 74, 0.45), rgba(245, 215, 160, 1));
    --gradient-subtle-tint: linear-gradient(180deg, rgba(90, 58, 18, 0.035), rgba(90, 58, 18, 0.015));
  }
}

/* ───────── Explicit override beats media query ───────── */
html[data-theme="dark"] {
  color-scheme: dark;
  --bg-base: #0f0e0c; --bg-surface: #191714; --bg-elevated: #221f1b; --bg-overlay: #2a2622;
  --text-primary: #e8e0d4; --text-secondary: #b8ad9e; --text-tertiary: #887d6e; --text-muted: #5a5248;
  --text-on-accent: #0f0e0c;
  --accent: #d4a04a; --accent-hover: #e0b35a;
  --accent-muted: rgba(212, 160, 74, 0.12); --accent-subtle: rgba(212, 160, 74, 0.06);
  --accent-glow: rgba(212, 160, 74, 0.22);
  --color-public: #7a9e6b; --color-private: #c45c3c; --color-unlisted: #b8ad9e;
  --color-edit: #d4a04a; --color-wikilink: #d4a04a; --color-wikilink-broken: #c45c3c;
  --color-external: #7a9bb5; --color-success: #7a9e6b; --color-warning: #d4a04a; --color-error: #c45c3c;
  --color-error-soft: #d88c75;
  --rgb-public: 122, 158, 107; --rgb-private: 196, 92, 60; --rgb-accent: 212, 160, 74;
  --border-default: rgba(200, 180, 150, 0.08); --border-emphasis: rgba(200, 180, 150, 0.15);
  --border-strong: rgba(200, 180, 150, 0.25); --border-accent: rgba(212, 160, 74, 0.4);
  --control-bg: rgba(0, 0, 0, 0.2); --control-bg-hover: rgba(200, 180, 150, 0.08);
  --con

... [44645 bytes truncated] ...

opped (user moved on before fetch resolved),
        // drop the response on the floor — otherwise we leak an orphan card
        var idx = stack.findIndex(function(s) { return s.el === c; });
        if (idx < 0) { c.remove(); return; }
        if (!res.ok || !res.data) {
          // wikihub-spwp: 404 → show stub card instead of silently vanishing.
          // covers "Related to" links whose targets don't exist in the wiki.
          var fakeLink = document.createElement('a');
          fakeLink.setAttribute('href', '/@' + parsed.owner + '/' + parsed.slug + '/' + parsed.path);
          fakeLink.dataset.target = parsed.path.replace(/\.md$/, '');
          fakeLink.textContent = parsed.path;
          c.remove();
          stack.splice(idx, 1);
          openStubPreview(fakeLink, rect, depth);
          return;
        }
        var data = res.data;
        data._owner = parsed.owner;
        data._slug = parsed.slug;
        cache[key] = data;
        var newC = buildCard(data, depth);
        document.body.appendChild(newC);
        positionCard(newC, rect, depth);
        c.remove();
        stack[idx] = { el: newC, depth: depth };
      })
      .catch(function() { removeLoadingFromStack(); c.remove(); });
  }

  // wikihub-spwp: stub cards for wikilinks pointing at pages that do not exist.
  // .wikilink-broken is set by app/renderer.py:321 for unresolved [[links]].
  // Show a dedicated card (no fetch) so the preview doesn't silently vanish.
  function openStubPreview(linkEl, rect, depth) {
    var c = document.createElement('div');
    c.className = 'hover-preview stub';
    c.style.zIndex = 300 + depth;
    c.dataset.depth = depth;

    var label = document.createElement('div');
    label.className = 'hover-preview-stub-label';
    label.textContent = 'Stub';
    c.appendChild(label);

    var titleEl = document.createElement('div');
    titleEl.className = 'hover-preview-title';
    titleEl.textContent = linkEl.dataset.target || linkEl.textContent.trim();
    c.appendChild(titleEl);

    var body = document.createElement('div');
    body.className = 'hover-preview-stub-body';
    body.textContent = 'Page not created yet.';
    c.appendChild(body);

    var create = document.createElement('a');
    create.className = 'hover-preview-stub-create';
    create.textContent = 'Create this page →';
    create.href = linkEl.getAttribute('href');
    c.appendChild(create);

    c.addEventListener('mouseenter', function() { cancelClose(); });
    c.addEventListener('mouseleave', onCardLeave(depth));
    document.body.appendChild(c);
    positionCard(c, rect, depth);
    stack.push({ el: c, depth: depth });
  }

  // page-level hover detection — immediate, no delay
  var lastHoverEl = null;
  document.addEventListener('mouseover', function(e) {
    var el = e.target.closest('.wikilink, .article a[href^="/@"]');
    if (!el || el === lastHoverEl) return;
    if (el.closest('.hover-preview')) return;
    lastHoverEl = el;
    var href = el.getAttribute('href');
    if (!href || href.startsWith('#')) return;

    cancelClose();
    closeFromDepth(0);

    if (el.classList.contains('wikilink-broken')) {
      openStubPreview(el, el.getBoundingClientRect(), 0);
      return;
    }

    var parsed = parseWikiUrl(href);
    if (!parsed) return;
    openPreview(parsed, el.getBoundingClientRect(), 0);
  });

  document.addEventListener('mouseout', function(e) {
    var el = e.target.closest('.wikilink, .article a[href^="/@"]');
    if (!el) return;
    if (el.closest('.hover-preview')) return;
    var related = e.relatedTarget;
    if (related && related.closest && related.closest('.hover-preview')) return;
    lastHoverEl = null;
    closeAll();
  });

  // click anywhere outside cards closes entire stack (and any orphans)
  document.addEventListener('click', function(e) {
    if (e.target.closest('.hover-preview')) return;
    cancelClose();
    closeFromDepth(0);
    lastHoverEl = null;
  });
})();
</script>
<script>
// PWA: register service worker, handle "new version available", offer "Add to Home Screen"
(function() {
  if ('serviceWorker' in navigator) {
    window.addEventListener('load', function() {
      navigator.serviceWorker.register('/static/sw.js', { scope: '/' })
        .then(function(reg) {
          // Check for updates whenever the user returns to the tab
          document.addEventListener('visibilitychange', function() {
            if (document.visibilityState === 'visible') reg.update();
          });
          reg.addEventListener('updatefound', function() {
            var nw = reg.installing;
            if (!nw) return;
            nw.addEventListener('statechange', function() {
              if (nw.state === 'installed' && navigator.serviceWorker.controller) {
                // New version waiting — auto-activate on next nav
                nw.postMessage('SKIP_WAITING');
              }
            });
          });
        })
        .catch(function(){});
    });
  }

  // Add-to-Home-Screen: capture the install prompt; show a small banner on second visit.
  // Mobile-only (wikihub-2q0d): desktop Chrome/Edge also fire beforeinstallprompt, but the
  // banner is only wanted on phones/tablets, so gate on touch-first UA/pointer.
  var deferredPrompt = null;
  function isMobileDevice() {
    if (/Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)) return true;
    return !!(window.matchMedia && window.matchMedia('(pointer: coarse)').matches &&
              window.matchMedia('(max-width: 1024px)').matches);
  }
  window.addEventListener('beforeinstallprompt', function(e) {
    e.preventDefault();
    deferredPrompt = e;
    try {
      var visits = parseInt(localStorage.getItem('wh_visit_count') || '0', 10) + 1;
      localStorage.setItem('wh_visit_count', String(visits));
      var dismissed = localStorage.getItem('wh_a2hs_dismissed');
      var alreadyInstalled = window.matchMedia && window.matchMedia('(display-mode: standalone)').matches;
      if (isMobileDevice() && visits >= 2 && !dismissed && !alreadyInstalled) showA2HSBanner();
    } catch(e) {}
  });

  function showA2HSBanner() {
    if (document.getElementById('wh-a2hs')) return;
    var b = document.createElement('div');
    b.id = 'wh-a2hs';
    b.setAttribute('style',
      'position:fixed;left:12px;right:12px;bottom:max(12px,env(safe-area-inset-bottom));' +
      'z-index:300;background:var(--bg-elevated,#1a1814);color:var(--text-primary,#f3eee4);' +
      'border:1px solid var(--border-default,#2a2620);border-radius:12px;padding:12px 14px;' +
      'box-shadow:0 8px 32px rgba(0,0,0,0.35);display:flex;gap:12px;align-items:center;' +
      'font-size:0.875rem;line-height:1.4;max-width:480px;margin:0 auto;');
    b.innerHTML =
      '<div style="flex:1">Install <b>wikihub</b> to your home screen for a faster, full-screen reading experience.</div>' +
      '<button id="wh-a2hs-yes" style="background:var(--accent,#d4a04a);color:#18130a;border:none;border-radius:8px;padding:8px 12px;font-weight:600;cursor:pointer;font-family:inherit">Install</button>' +
      '<button id="wh-a2hs-no" style="background:transparent;color:var(--text-muted,#b8ad9e);border:none;cursor:pointer;font-family:inherit;padding:6px 4px" aria-label="Dismiss">✕</button>';
    document.body.appendChild(b);
    document.getElementById('wh-a2hs-yes').addEventListener('click', function() {
      if (!deferredPrompt) { b.remove(); return; }
      deferredPrompt.prompt();
      deferredPrompt.userChoice.then(function(choice) {
        if (choice.outcome === 'accepted') {
          try { localStorage.setItem('wh_a2hs_dismissed', '1'); } catch(e) {}
        }
        deferredPrompt = null;
        b.remove();
      });
    });
    document.getElementById('wh-a2hs-no').addEventListener('click', function() {
      try { localStorage.setItem('wh_a2hs_dismissed', '1'); } catch(e) {}
      b.remove();
    });
  }

  // Count this visit even if beforeinstallprompt never fires (iOS doesn't fire it)
  try {
    var v = parseInt(localStorage.getItem('wh_visit_count') || '0', 10) + 1;
    localStorage.setItem('wh_visit_count', String(v));
  } catch(e) {}
})();
</script>

</body>
</html>
```
</details>
<details>
<summary>Evidence: Captured global activity RSS</summary>

```text
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
<channel>
<title>WikiHub — recent activity</title>
<link>http://127.0.0.1:7644/activity</link>
<description>Recent page creations and updates across public WikiHub wikis.</description>
<atom:link href="http://127.0.0.1:7644/activity.rss" rel="self" type="application/rss+xml" />
<item>
<title>Public Note (created in Public Wiki)</title>
<link>http://127.0.0.1:7644/@activitytester/pubwiki/wiki/public-note</link>
<guid isPermaLink="false">http://127.0.0.1:7644/@activitytester/pubwiki/wiki/public-note#created-Sat, 18 Jul 2026 04:37:41 +0000</guid>
<pubDate>Sat, 18 Jul 2026 04:37:41 +0000</pubDate>
<description>Created in Public Wiki by activitytester</description>
</item>
</channel>
</rss>
```
</details>
<details>
<summary>Evidence: Captured per-wiki RSS for unlisted wiki</summary>

```text
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
<channel>
<title>Secret Wiki — activity</title>
<link>http://127.0.0.1:7644/@activitytester/secretwiki</link>
<description>Recent page activity in Secret Wiki.</description>
<atom:link href="http://127.0.0.1:7644/@activitytester/secretwiki/activity.rss" rel="self" type="application/rss+xml" />
<item>
<title>Unlisted Note (created in Secret Wiki)</title>
<link>http://127.0.0.1:7644/@activitytester/secretwiki/wiki/unlisted-note</link>
<guid isPermaLink="false">http://127.0.0.1:7644/@activitytester/secretwiki/wiki/unlisted-note#created-Sat, 18 Jul 2026 04:37:42 +0000</guid>
<pubDate>Sat, 18 Jul 2026 04:37:42 +0000</pubDate>
<description>Created in Secret Wiki by activitytester</description>
</item>
</channel>
</rss>
```
</details>
<details>
<summary>Evidence: Manual visibility evidence from captured HTML/RSS</summary>

```text
global_html: Public Note
global_rss: Public Note
per_wiki_rss: Unlisted Note
global-activity.rss ['Public Note (created in Public Wiki)'] ['http://127.0.0.1:7644/@activitytester/pubwiki/wiki/public-note']
secretwiki-activity.rss ['Unlisted Note (created in Secret Wiki)'] ['http://127.0.0.1:7644/@activitytester/secretwiki/wiki/unlisted-note']
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `app/routes/wiki.py` - merge conflict rebasing onto origin/main
- ⚠️ `app/templates/activity.html` - merge conflict rebasing onto origin/main
- ⚠️ `tests/test_e2e.py` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (6) ✅</summary>

- ⚠️ `app/routes/wiki.py:1478` - The per-wiki RSS feed first limits to the 300 newest pages and only then applies `_viewer_can_read_page`; a wiki with 300 newer private pages will omit older public/unlisted pages from an anonymous feed, even though those pages are readable and should be included. Iterate/query until 50 visible items are collected, or use a SQL visibility prefilter for anonymous/public cases before applying ACL checks.
- ⚠️ `app/templates/activity.html:170` - The global activity row is an `&lt;a&gt;` that contains another `&lt;a&gt;` for the wiki link. Nested anchors are invalid HTML and browsers will reparent/close the outer link unpredictably, so the row click target can break. Make the row a non-anchor wrapper with separate links, or remove the nested wiki anchor.

🔧 Fix: Fix activity feed visibility regressions
1 error still open:
- 🚨 `app/routes/wiki.py:1504` - Anonymous requests to a private-only wiki&#39;s `/activity.rss` still get a 200 RSS document whose title/description include `wiki.title`, even though the existing HTML activity/history routes gate private-only wikis before rendering metadata. Add the same `_viewer_can_see_any_page` permission check before building the feed so private wiki titles are not exposed to callers with no readable pages.

🔧 Fix: Gate private wiki RSS metadata
1 warning still open:
- ⚠️ `app/templates/_nav.html:9` - The new global `/activity` link points at a route that the subdomain middleware does not treat as global. On any `*.wikihub.md` host, `/activity` and `/activity.rss` will be rewritten into `/@user/activity` or `/@owner/slug/activity`, so the header link and global RSS URL are broken or resolve to a per-wiki surface from canonical subdomain pages. Add `/activity` to `_GLOBAL_PREFIXES` so both `/activity` and `/activity.rss` pass through like `/explore` and `/people`.

🔧 Fix: Fix global activity subdomain routing
1 warning still open:
- ⚠️ `app/subdomain_middleware.py:33` - Adding `/activity.rss` as a global passthrough means `https://&lt;wiki-subdomain&gt;.wikihub.md/activity.rss` always serves the site-wide feed. The existing canonical redirect still shortens `/@owner/slug/activity.rss` on apex or the same wiki subdomain to that short path, so the new per-wiki RSS route becomes unreachable for custom-subdomain wikis and the history-page RSS icon can land on the wrong feed. Add `/activity.rss` (and likely `/activity`) to the canonical redirect skip list so canonical `/@owner/slug/activity.rss` stays on the per-wiki route, while the header/global `/activity.rss` link remains global.

🔧 Fix: Fix per-wiki activity canonical routing
1 warning still open:
- ⚠️ `app/subdomain_middleware.py:32` - Adding `/activity` to the global prefix list makes every `/activity/...` request on user/wiki subdomains bypass rewriting, so a wiki page such as `https://recipes.wikihub.md/activity/foo` now hits the global app and 404s instead of resolving to `/@owner/slug/activity/foo`. Treat `/activity` and `/activity.rss` as exact global passthroughs, or add an exact-match exception before the prefix loop, so only the intended feed routes are reserved.

🔧 Fix: Fix activity subdomain passthrough
1 warning still open:
- ⚠️ `app/canonical_redirect.py:36` - Adding `/activity` to the broad suffix skip list also skips canonical redirects for deeper content paths such as `/@owner/slug/activity/menu`, because `_is_skipped` treats `s + &#34;/&#34; in path` as a match. Those pages still render on apex, but custom-subdomain wikis no longer get the expected canonical redirect for pages under an `activity/` folder. Make the activity skip exact to `/@owner/slug/activity` and `/@owner/slug/activity.rss` instead of applying it to all descendants.

🔧 Fix: Fix exact activity redirect skip
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`source .venv/bin/activate &amp;&amp; python3 tests/test_e2e.py` (setup attempt; failed because `.venv` was absent in this isolated worktree)</code>
- <code>Created a worktree-local Python 3.11 virtualenv and installed `requirements.txt` for testing only.</code>
- <code>Started an isolated throwaway PostgreSQL cluster inside the worktree on port 7643 and created `wikihub_test` after local Postgres.app blocked `localhost` auth behind an interactive permission dialog.</code>
- <code>`PGPORT=7643 .venv/bin/python tests/test_e2e.py` (112 passed, 0 failed; includes the new global activity, RSS, visibility, subdomain, and pagination tests).</code>
- <code>Started Flask locally on `127.0.0.1:7644`, created `activitytester`, seeded `pubwiki` with `Public Note`, and seeded `secretwiki` with `Unlisted Note` plus `Private Note`.</code>
- <code>Fetched `http://127.0.0.1:7644/activity`, `/activity.rss`, and `/@activitytester/secretwiki/activity.rss`; parsed/grepped captured outputs to confirm global HTML/RSS only contained `Public Note`, while per-wiki RSS contained `Unlisted Note` and not `Private Note`.</code>
- <code>Captured reviewer-visible screenshots for `/activity`, `/explore`, and `/@activitytester/pubwiki/history` using headless Chrome.</code>
- <code>Removed transient `.venv`, `.tmp-pg`, `.tmp-dev-repos`, `.tmp-chrome*`, and `/tmp/wikihub-test-repos`; final `git status --short` was clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
