### PR TITLE
fix(ui): synchronize hover preview controls

### DIFF
--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -101,6 +101,12 @@ Not GitHub. Not Notion. This is a knowledge publishing tool for people who live 
 - Logo: `[[wikihub]]` in mono font
 - Height: 56px. Items centered vertically.
 - No glassmorphism/blur. Clean border separation.
+- Dropdown menus that use `backdrop-filter` must be `visibility:hidden` while closed and `visibility:visible` when open, because Safari can render hidden blur on `opacity:0` elements.
+
+### Hover previews
+- Same-wiki links may show compact preview cards on hover.
+- Cards use `--bg-overlay`, `--border-emphasis`, `--hover-preview-shadow`, and `--radius-md`.
+- Include a low-emphasis text button to hide previews; the nav/account menus provide the matching per-browser `Hover previews` checkbox item.
 
 ### Cards (wiki cards, feature cards)
 - Background: `--bg-surface`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ tests are intentional — each one verifies a real user flow end-to-end or a bro
 5. **zip upload** — create wiki via web form with zip file
 6. **agent surfaces** — all discovery endpoints respond (llms.txt, AGENTS.md, .well-known/*)
 7. **ACL permissions** — private pages not readable without auth
-8. **reader behavior** — sidebar, page controls, side peek, live updates, and other browser-facing regressions
+8. **reader behavior** — sidebar, page controls, side peek, hover previews, live updates, and other browser-facing regressions
 9. **activity feeds** — global activity excludes non-public content; RSS links are well-formed and visibility-safe
 
 don't add unit tests for individual functions. if something breaks, add an e2e test that covers the broken flow. tests should run in <10 seconds.
@@ -88,6 +88,8 @@ host (`ubuntu@54.145.123.7`) — that's historical. Production is GCP now.
 - `app/page_utils.py` — canonical repo-path normalization plus `.wikihub/*` plumbing/content-page checks
 - `app/renderer.py` — markdown-it-py with wikilinks, KaTeX, footnotes, Obsidian embeds, wiki-relative link rewriting
 - `app/static/js/sidepeek.js` — desktop reader slide-over for same-wiki page links; fetches rendered body JSON via `?fragment=1`
+- `app/templates/base.html` — global chrome, hover-preview cards, search modal, theme/A2HS scripts
+- `app/templates/_nav.html` — shared nav/account menu, including the per-browser hover-preview toggle
 - `app/auth_utils.py` — password hashing, API key gen/verify, Bearer auth decorators
 - `app/routes/` — blueprints: main, auth, api, api_wikis, wiki, agent_surfaces, upload
 - `hooks/post-receive` — git→DB sync (installed into each wiki's bare repo)
@@ -103,6 +105,8 @@ host (`ubuntu@54.145.123.7`) — that's historical. Production is GCP now.
 - **`.wikihub/*` is plumbing, not content.** Only `.wikihub/acl` is exposed through generic page write APIs, and only to the wiki owner. ACL writes/replaces/patches/deletes/reverts, zip uploads containing `.wikihub/acl`, and git pushes that change `.wikihub/acl` must reindex inherited `Page.visibility` values and regenerate the public mirror. Other `.wikihub/*` paths are rejected by generic web/API page writes and excluded from page counts, public mirrors, discovery, search, backlinks, sidebars, history/diff, zip exports, and agent-chat context.
 - **pinned pages float to the top of the sidebar.** Frontmatter `pinned: true` on a page renders it in a top section of the wiki's left sidebar (subtle divider, then folders/pages alphabetical as usual). Frontmatter-wins, mirroring the visibility precedent. Read permissions still apply — a pinned page the viewer can't read simply doesn't appear. **Pin/unpin via the MCP `wikihub_update_page` tool by setting/removing `pinned: true` in the page's frontmatter — no dedicated tool.** Integrators (e.g. GroupBrain-provisioned wikis) can pin rules / chat-history pages the same way, by writing `pinned: true` frontmatter from their side. Implemented in `_build_sidebar_tree` (`app/routes/wiki.py`) + `render_sidebar` macro and async JS in `app/templates/reader.html`. Regression: `test_pinned_pages_sort_to_top`.
 - **empty nav/sidebar surfaces show explicit unconditional copy, never blankness.** A profile with no visible wikis/pages shows "No public pages here — this account may have unlisted content reachable by direct link."; a wiki sidebar with no visible pages shows "No listed pages visible to you." The wording is **identical whether or not unlisted content exists** — no information leak (same no-leak rule as the 403-vs-404 distinction). Zero-case profile wiki count reads "No public wikis". Regressions: `test_empty_sidebar_copy`, `test_empty_profile_copy_no_leak`.
+- **hover previews are browser-local and reversible.** Same-wiki hover preview cards are enabled by default for logged-in and logged-out readers. The card footer plus desktop/mobile nav menus can disable them per browser by setting localStorage `wh_hover_previews=off`; toggles expose `role="menuitemcheckbox"` and accurate `aria-checked`, dispatch `wikihub:hover-previews-changed`, sync across tabs via `storage`, and immediately close any active/in-flight preview. Regression: `test_hover_previews_toggle`.
+- **closed backdrop-filter menus must be visibility-hidden.** Safari applies `backdrop-filter` even on `opacity:0` account menus, causing phantom blur. Any always-rendered nav/account menu with `backdrop-filter` needs closed-state `visibility:hidden` and open-state `visibility:visible` in every copy of the nav CSS, including landing. Regression: `test_nav_menu_no_phantom_backdrop_blur`.
 - **API keys start with `wh_`**, SHA-256 hashed in DB, shown once on creation.
 - **wiki caps resolve per user.** `User.wiki_limit` overrides `MAX_WIKIS_PER_USER`; enforcement and `/api/v1/me/capabilities` must use `User.effective_wiki_limit()`.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ GitHub for LLM wikis. A hosting platform for markdown knowledge bases with per-f
 - Social: fork, star, explore, activity feeds, profiles
 - Rendering: KaTeX math, syntax highlighting, wikilinks, footnotes, Obsidian embeds, wiki-relative links
 - Reader side peek: same-wiki page links open in a right-side preview panel on desktop
+- Hover preview cards: wiki links preview on hover, with a per-browser opt-out in the preview card and nav menus
 - Every wiki is a real git repo — clone, push, blame, bisect
 
 ## Quick start
@@ -66,6 +67,10 @@ Authorization: Bearer wh_...
 Content negotiation: `Accept: text/markdown` on any page URL returns raw markdown. Or append `.md`.
 For the desktop reader side peek, append `?fragment=1` to a rendered page URL to get JSON
 `{title, html, url, path}` for the article body only; the route uses the same page ACL checks.
+Hover preview cards use the same rendered-page data path and can be disabled
+per browser without logging in via the "hide previews" card action or the
+`Hover previews` menu toggle; the setting is stored in localStorage as
+`wh_hover_previews=off` and syncs across open tabs.
 Use `?meta=1` on the page-read API when a client only needs the latest
 `content_hash` and `updated_at` for lightweight change polling; it enforces the
 same read permissions as a full page read and does not return page content.

--- a/app/routes/agent_surfaces.py
+++ b/app/routes/agent_surfaces.py
@@ -565,6 +565,10 @@ Or append `.md` to the URL.
 For rendered HTML without the full reader chrome, append `?fragment=1` to a
 page URL. The response is JSON `{title, html, url, path}` for the article body
 only and uses the same ACL checks as the full page route.
+Hover preview cards use the same rendered-page data path and can be disabled
+per browser without logging in via the "hide previews" card action or the
+`Hover previews` menu toggle; the setting is stored in localStorage as
+`wh_hover_previews=off` and syncs across open tabs.
 For markdown, fragment, and full-page reads, a genuinely missing path stays 404;
 an existing path outside your access returns the restricted 403/401 signal
 without page fields.

--- a/app/templates/_nav.html
+++ b/app/templates/_nav.html
@@ -72,7 +72,7 @@
           <span>Settings</span>
           <span class="menu-hint">account</span>
         </a>
-        <button type="button" class="nav-account-item" role="menuitem" data-hover-previews-toggle>
+        <button type="button" class="nav-account-item" role="menuitemcheckbox" aria-checked="true" data-hover-previews-toggle>
           <span>Hover previews</span>
           <span class="menu-hint" data-hover-previews-state>on</span>
         </button>
@@ -104,7 +104,7 @@
       <a href="/shared" class="nav-mobile-item" role="menuitem">Shared</a>
       <a href="/settings" class="nav-mobile-item" role="menuitem">Settings</a>
     {% endif %}
-    <button type="button" class="nav-mobile-item" role="menuitem" data-hover-previews-toggle>
+    <button type="button" class="nav-mobile-item" role="menuitemcheckbox" aria-checked="true" data-hover-previews-toggle>
       Hover previews: <span data-hover-previews-state>on</span>
     </button>
     {% if current_user and current_user.is_authenticated %}
@@ -146,8 +146,10 @@
 // wikihub-lzex: hover-previews on/off toggle (per-browser localStorage flag,
 // read by the hover-preview script in base.html; works logged out)
 (function(){
+  var settingKey = 'wh_hover_previews';
+  var changeEvent = 'wikihub:hover-previews-changed';
   function isOn(){
-    try { return localStorage.getItem('wh_hover_previews') !== 'off'; }
+    try { return localStorage.getItem(settingKey) !== 'off'; }
     catch(e){ return true; }
   }
   var toggles = document.querySelectorAll('[data-hover-previews-toggle]');
@@ -157,14 +159,21 @@
     toggles.forEach(function(b){
       var s = b.querySelector('[data-hover-previews-state]');
       if (s) s.textContent = on ? 'on' : 'off';
-      b.setAttribute('aria-pressed', on ? 'true' : 'false');
+      b.setAttribute('aria-checked', on ? 'true' : 'false');
     });
   }
   toggles.forEach(function(b){
     b.addEventListener('click', function(){
-      try { localStorage.setItem('wh_hover_previews', isOn() ? 'off' : 'on'); } catch(e){}
+      try { localStorage.setItem(settingKey, isOn() ? 'off' : 'on'); } catch(e){}
       render();
+      document.dispatchEvent(new CustomEvent(changeEvent, {
+        detail: { enabled: isOn() }
+      }));
     });
+  });
+  document.addEventListener(changeEvent, render);
+  window.addEventListener('storage', function(e){
+    if (e.key === settingKey) render();
   });
   render();
 })();

--- a/app/templates/_nav.html
+++ b/app/templates/_nav.html
@@ -72,6 +72,10 @@
           <span>Settings</span>
           <span class="menu-hint">account</span>
         </a>
+        <button type="button" class="nav-account-item" role="menuitem" data-hover-previews-toggle>
+          <span>Hover previews</span>
+          <span class="menu-hint" data-hover-previews-state>on</span>
+        </button>
         <a href="/auth/logout" class="nav-account-item logout" role="menuitem">
           <span>Logout</span>
           <span class="menu-hint">exit</span>
@@ -99,6 +103,11 @@
       <a href="/@{{ current_user.username }}" class="nav-mobile-item" role="menuitem">My Wiki</a>
       <a href="/shared" class="nav-mobile-item" role="menuitem">Shared</a>
       <a href="/settings" class="nav-mobile-item" role="menuitem">Settings</a>
+    {% endif %}
+    <button type="button" class="nav-mobile-item" role="menuitem" data-hover-previews-toggle>
+      Hover previews: <span data-hover-previews-state>on</span>
+    </button>
+    {% if current_user and current_user.is_authenticated %}
       <a href="/auth/logout" class="nav-mobile-item nav-mobile-item-danger" role="menuitem">Logout</a>
     {% else %}
       <a href="/auth/login?next={{ request.path|urlencode }}" class="nav-mobile-item" role="menuitem">Sign in</a>
@@ -132,5 +141,31 @@
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && menu.classList.contains('open')) close();
   });
+})();
+
+// wikihub-lzex: hover-previews on/off toggle (per-browser localStorage flag,
+// read by the hover-preview script in base.html; works logged out)
+(function(){
+  function isOn(){
+    try { return localStorage.getItem('wh_hover_previews') !== 'off'; }
+    catch(e){ return true; }
+  }
+  var toggles = document.querySelectorAll('[data-hover-previews-toggle]');
+  if (!toggles.length) return;
+  function render(){
+    var on = isOn();
+    toggles.forEach(function(b){
+      var s = b.querySelector('[data-hover-previews-state]');
+      if (s) s.textContent = on ? 'on' : 'off';
+      b.setAttribute('aria-pressed', on ? 'true' : 'false');
+    });
+  }
+  toggles.forEach(function(b){
+    b.addEventListener('click', function(){
+      try { localStorage.setItem('wh_hover_previews', isOn() ? 'off' : 'on'); } catch(e){}
+      render();
+    });
+  });
+  render();
 })();
 </script>

--- a/app/templates/agents.html
+++ b/app/templates/agents.html
@@ -223,6 +223,7 @@ wikihub mcp-config                # prints mcpServers JSON pre-filled</pre></div
   <h2>Content negotiation</h2>
   <p><code>Accept: text/markdown</code> on any page URL returns raw markdown. Or append <code>.md</code>.</p>
   <p>For rendered HTML without the full reader chrome, append <code>?fragment=1</code> to a page URL. The response is JSON with <code>title</code>, <code>html</code>, <code>url</code>, and <code>path</code>, and it uses the same ACL checks as the full page route.</p>
+  <p>Hover preview cards use the same rendered-page data path and can be disabled per browser without logging in via the <code>hide previews</code> card action or the <code>Hover previews</code> menu toggle; the setting is stored in localStorage as <code>wh_hover_previews=off</code> and syncs across open tabs.</p>
   <p>For markdown, fragment, and full-page reads, a genuinely missing path stays <code>404</code>; an existing path outside your access returns the restricted <code>403</code>/<code>401</code> signal without page fields.</p>
 
   <h2>Discovery</h2>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -157,6 +157,9 @@ a:hover { text-decoration: underline; }
   font-size: 0.9375rem;
   text-decoration: none;
   border-radius: var(--radius-sm);
+  /* button-as-menuitem reset (hover previews toggle, wikihub-lzex) */
+  width: 100%; background: none; border: none; cursor: pointer;
+  font-family: inherit; text-align: left;
 }
 .nav-mobile-item:hover { background: var(--accent-subtle); text-decoration: none; }
 .nav-mobile-item-danger { color: var(--color-error-soft); }
@@ -217,12 +220,17 @@ a:hover { text-decoration: underline; }
   opacity: 0;
   transform: translateY(-4px);
   pointer-events: none;
-  transition: opacity 0.14s ease, transform 0.14s ease;
+  /* visibility:hidden while closed — Safari applies backdrop-filter even at
+     opacity:0, leaving a phantom blurred rectangle (wikihub-i4am) */
+  visibility: hidden;
+  transition: opacity 0.14s ease, transform 0.14s ease, visibility 0s linear 0.14s;
 }
 .nav-account.open .nav-account-menu {
   opacity: 1;
   transform: translateY(0);
   pointer-events: auto;
+  visibility: visible;
+  transition: opacity 0.14s ease, transform 0.14s ease, visibility 0s;
 }
 .nav-account-menu::before {
   content: '';
@@ -258,6 +266,9 @@ a:hover { text-decoration: underline; }
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   font-size: 0.8125rem;
+  /* button-as-menuitem reset (hover previews toggle, wikihub-lzex) */
+  width: 100%; background: none; border: none; cursor: pointer;
+  font-family: inherit; text-align: left;
   text-decoration: none;
 }
 .nav-account-item:hover {
@@ -402,6 +413,12 @@ a:hover { text-decoration: underline; }
 .hover-preview-related-label { font-size: 0.6875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-muted); margin-bottom: 4px; }
 .hover-preview-link { display: block; font-size: 0.75rem; color: var(--accent); text-decoration: none; padding: 2px 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .hover-preview-link:hover { text-decoration: underline; }
+.hover-preview-disable {
+  display: block; margin-top: 8px; padding: 0;
+  font-size: 0.6875rem; color: var(--text-muted);
+  background: none; border: none; cursor: pointer; font-family: inherit;
+}
+.hover-preview-disable:hover { color: var(--text-secondary); text-decoration: underline; }
 
 /* .theme-toggle styles live in _theme.html */
 
@@ -563,6 +580,30 @@ document.addEventListener('DOMContentLoaded', () => {
   var hideTimer = null;
   var cache = {};
 
+  // wikihub-lzex: per-browser opt-out, no login required. Toggled from the
+  // card footer, the account menu, and the mobile nav panel (_nav.html).
+  function previewsOff() {
+    try { return localStorage.getItem('wh_hover_previews') === 'off'; }
+    catch (e) { return false; }
+  }
+  function disablePreviews() {
+    try { localStorage.setItem('wh_hover_previews', 'off'); } catch (e) {}
+    closeAll();
+  }
+  function appendDisableAction(c) {
+    var d = document.createElement('button');
+    d.type = 'button';
+    d.className = 'hover-preview-disable';
+    d.textContent = 'hide previews';
+    d.title = 'Turn off hover previews (re-enable from the menu)';
+    d.addEventListener('click', function(ev) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      disablePreviews();
+    });
+    c.appendChild(d);
+  }
+
   function parseWikiUrl(href) {
     try {
       var url = new URL(href, window.location.origin);
@@ -698,6 +739,8 @@ document.addEventListener('DOMContentLoaded', () => {
       c.appendChild(relatedEl);
     }
 
+    appendDisableAction(c);
+
     // keep stack alive while mouse is on any card
     c.addEventListener('mouseenter', function() { cancelClose(); });
     c.addEventListener('mouseleave', onCardLeave(depth));
@@ -827,6 +870,8 @@ document.addEventListener('DOMContentLoaded', () => {
     create.href = linkEl.getAttribute('href');
     c.appendChild(create);
 
+    appendDisableAction(c);
+
     c.addEventListener('mouseenter', function() { cancelClose(); });
     c.addEventListener('mouseleave', onCardLeave(depth));
     document.body.appendChild(c);
@@ -837,6 +882,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // page-level hover detection — immediate, no delay
   var lastHoverEl = null;
   document.addEventListener('mouseover', function(e) {
+    if (previewsOff()) return; // wikihub-lzex
     var el = e.target.closest('.wikilink, .article a[href^="/@"]');
     if (!el || el === lastHoverEl) return;
     if (el.closest('.hover-preview')) return;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -579,16 +579,20 @@ document.addEventListener('DOMContentLoaded', () => {
   var stack = []; // array of {el: card element, depth: number}
   var hideTimer = null;
   var cache = {};
+  var previewSettingKey = 'wh_hover_previews';
+  var previewChangeEvent = 'wikihub:hover-previews-changed';
 
   // wikihub-lzex: per-browser opt-out, no login required. Toggled from the
   // card footer, the account menu, and the mobile nav panel (_nav.html).
   function previewsOff() {
-    try { return localStorage.getItem('wh_hover_previews') === 'off'; }
+    try { return localStorage.getItem(previewSettingKey) === 'off'; }
     catch (e) { return false; }
   }
   function disablePreviews() {
-    try { localStorage.setItem('wh_hover_previews', 'off'); } catch (e) {}
-    closeAll();
+    try { localStorage.setItem(previewSettingKey, 'off'); } catch (e) {}
+    document.dispatchEvent(new CustomEvent(previewChangeEvent, {
+      detail: { enabled: false }
+    }));
   }
   function appendDisableAction(c) {
     var d = document.createElement('button');
@@ -648,6 +652,17 @@ document.addEventListener('DOMContentLoaded', () => {
   function cancelClose() {
     clearTimeout(hideTimer);
   }
+
+  function syncPreviewState() {
+    if (!previewsOff()) return;
+    cancelClose();
+    closeFromDepth(0);
+    lastHoverEl = null;
+  }
+  document.addEventListener(previewChangeEvent, syncPreviewState);
+  window.addEventListener('storage', function(e) {
+    if (e.key === previewSettingKey) syncPreviewState();
+  });
 
   function positionCard(c, rect, depth) {
     var preferBelow = (depth % 2 === 0);

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -157,10 +157,15 @@
       border-radius: var(--radius-md); border: 1px solid var(--border-emphasis);
       background: var(--menu-bg); backdrop-filter: blur(12px); box-shadow: none;
       opacity: 0; transform: translateY(-4px); pointer-events: none;
-      transition: opacity 0.14s ease, transform 0.14s ease;
+      /* visibility:hidden while closed — Safari applies backdrop-filter even at
+         opacity:0, leaving a phantom blurred rectangle (wikihub-i4am) */
+      visibility: hidden;
+      transition: opacity 0.14s ease, transform 0.14s ease, visibility 0s linear 0.14s;
     }
     .nav-account.open .nav-account-menu {
       opacity: 1; transform: translateY(0); pointer-events: auto;
+      visibility: visible;
+      transition: opacity 0.14s ease, transform 0.14s ease, visibility 0s;
     }
     .nav-account-summary { padding: 10px 12px 12px; border-bottom: 1px solid var(--border-default); margin-bottom: 4px; }
     .nav-account-summary strong { display: block; font-size: 0.875rem; color: var(--text-primary); }

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -910,6 +910,47 @@ def test_a2hs_banner_gated_to_mobile(client):
     assert "isMobileDevice()" in handler, "showA2HSBanner() not guarded by isMobileDevice()"
 
 
+def test_nav_menu_no_phantom_backdrop_blur(client):
+    """regression (wikihub-i4am): Safari applies backdrop-filter even on
+    opacity:0 elements, so the closed account menu left a phantom blurred
+    rectangle on screen. The closed-state CSS must include visibility:hidden
+    (and the open state visibility:visible) wherever backdrop-filter is used
+    on the always-rendered nav menu."""
+    checked = 0
+    for url in ["/explore", "/"]:
+        r = client.get(url)
+        assert r.status_code == 200
+        html = r.data.decode()
+        if ".nav-account-menu {" not in html:
+            continue
+        closed = html.split(".nav-account-menu {", 1)[1].split("}", 1)[0]
+        if "backdrop-filter" not in closed:
+            continue
+        checked += 1
+        assert "visibility: hidden" in closed, (
+            f"{url}: closed .nav-account-menu has backdrop-filter without "
+            "visibility:hidden — Safari renders a phantom blur (wikihub-i4am)"
+        )
+        opened = html.split(".nav-account.open .nav-account-menu {", 1)[1].split("}", 1)[0]
+        assert "visibility: visible" in opened, f"{url}: open menu never becomes visible"
+    assert checked > 0, "no page served the backdrop-filter nav menu CSS — test needs updating"
+
+
+def test_hover_previews_toggle(client):
+    """regression (wikihub-lzex): hover link previews must be disableable
+    per-browser (localStorage wh_hover_previews) without login. The served
+    page must contain the guard in the hover script and a toggle control."""
+    r = client.get("/explore")
+    assert r.status_code == 200
+    html = r.data.decode()
+    assert "wh_hover_previews" in html, "hover-previews localStorage flag missing"
+    assert "previewsOff()" in html, "hover script missing previewsOff() guard"
+    hover_handler = html.split("page-level hover detection", 1)[1].split("closest('.wikilink", 1)[0]
+    assert "previewsOff()" in hover_handler, "mouseover handler not guarded by previewsOff()"
+    assert "data-hover-previews-toggle" in html, "no toggle control in nav"
+    assert "hover-preview-disable" in html, "no quick-disable action styling for the card"
+
+
 def test_token_and_settings(client):
     r = client.post("/auth/signup", data={"username": "webuser", "password": "testpass123"}, follow_redirects=False)
     assert r.status_code == 302
@@ -7373,6 +7414,8 @@ def run_all():
             ("anonymous upload (wikihub-i2xm)", lambda: test_anonymous_upload(app)),
             ("agent surfaces", lambda: test_agent_surfaces(client)),
             ("A2HS banner mobile-only (wikihub-2q0d)", lambda: test_a2hs_banner_gated_to_mobile(client)),
+            ("nav menu phantom blur (wikihub-i4am)", lambda: test_nav_menu_no_phantom_backdrop_blur(client)),
+            ("hover previews toggle (wikihub-lzex)", lambda: test_hover_previews_toggle(client)),
             ("token + settings", lambda: test_token_and_settings(client)),
             ("client_config hint", lambda: test_client_config_hint(client)),
             ("magic link login", lambda: test_magic_link_login(client)),

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -948,6 +948,11 @@ def test_hover_previews_toggle(client):
     hover_handler = html.split("page-level hover detection", 1)[1].split("closest('.wikilink", 1)[0]
     assert "previewsOff()" in hover_handler, "mouseover handler not guarded by previewsOff()"
     assert "data-hover-previews-toggle" in html, "no toggle control in nav"
+    assert 'role="menuitemcheckbox"' in html, "toggle lacks checkbox menu semantics"
+    assert 'aria-checked="true"' in html, "toggle lacks initial checked state"
+    assert "wikihub:hover-previews-changed" in html, "toggle surfaces do not synchronize immediately"
+    assert "window.addEventListener('storage'" in html, "setting changes do not synchronize across tabs"
+    assert "syncPreviewState()" in html, "disabling does not cancel an open or in-flight preview"
     assert "hover-preview-disable" in html, "no quick-disable action styling for the card"
 
 


### PR DESCRIPTION
## Intent

The developer wanted PR #24 for WikiHub made merge-ready after origin/main advanced to commit 76deb2db548ad26eee2cc983094d73ede51e80d7 via PR #25, causing ancestry and dry-merge conflicts with the PR #24 head 8110f1f77be29ec7c1676175ec7e4e0884cc5ba5. They asked the agent to resume the existing /tmp/wh-ui-fixes lane, preserve every commit and backup stash, rebase PR #24 onto that exact main commit, and revalidate it through no-mistakes. They specifically required rerunning the overlapping PR #23, PR #25, PR #22, i4am, and lzex regressions, updating PR #24, and reporting the exact resulting head and green status. They explicitly constrained the agent not to touch wikihub-s6ao, not to deploy, and not to merge the PR.

## What Changed

- Added a browser-local hover preview opt-out that stays synchronized across the preview card footer, desktop/mobile nav menus, tabs, and in-flight preview state.
- Updated nav/menu CSS so closed backdrop-filter menus become `visibility: hidden`, preventing phantom blur while preserving the visible open state.
- Synced the hover-preview/menu behavior into agent-facing docs and added e2e coverage for the toggle and closed-menu visibility behavior.

## Risk Assessment

✅ Low: The branch is narrowly scoped to hover-preview opt-out behavior, Safari menu visibility, matching documentation, and targeted e2e assertions; I did not find material correctness, security, performance, or maintainability risks in the changed code.

## Testing

After setup retries showed this worktree lacked `.venv`, system Python lacked dependencies, and shared Postgres.app was blocked by a permission prompt, I used isolated Python and Postgres instances under the evidence directory; the full e2e harness passed, and Playwright captured real rendered evidence for the hover-preview opt-out and closed-menu visibility behavior.

- Evidence: Hover preview card before opt-out (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXWD7SRFV1QF5KFAF00TS0TE/hover-preview-card.png</code>)
- Evidence: Account menu showing hover previews off (local file: <code>/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXWD7SRFV1QF5KFAF00TS0TE/account-menu-hover-previews-off.png</code>)
<details>
<summary>Evidence: Browser state verification</summary>

<code>{&#10;&#34;afterDisable&#34;: {&#10;&#34;setting&#34;: &#34;off&#34;,&#10;&#34;cards&#34;: 0&#10;},&#10;&#34;afterRehover&#34;: {&#10;&#34;setting&#34;: &#34;off&#34;,&#10;&#34;cardsAfterHover&#34;: 0&#10;},&#10;&#34;closedMenuComputedStyleAfterTransition&#34;: {&#10;&#34;visibility&#34;: &#34;hidden&#34;,&#10;&#34;pointerEvents&#34;: &#34;none&#34;,&#10;&#34;opacity&#34;: &#34;0&#34;,&#10;&#34;backdropFilter&#34;: &#34;blur(12px)&#34;&#10;}&#10;}</code>

```text
{
  "afterDisable": {
    "setting": "off",
    "cards": 0
  },
  "afterRehover": {
    "setting": "off",
    "cardsAfterHover": 0
  },
  "closedMenuComputedStyle": {
    "visibility": "visible",
    "pointerEvents": "none",
    "opacity": "0.885829",
    "backdropFilter": "blur(12px)"
  },
  "openMenuComputedStyle": {
    "visibility": "visible",
    "pointerEvents": "auto",
    "opacity": "0.102826",
    "backdropFilter": "blur(12px)"
  },
  "closedMenuComputedStyleAfterTransition": {
    "visibility": "hidden",
    "pointerEvents": "none",
    "opacity": "0",
    "backdropFilter": "blur(12px)"
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/fix-ui-nitpicks
- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`source .venv/bin/activate &amp;&amp; DATABASE_URL=postgresql://localhost/wikihub_test REPOS_DIR=/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXWD7SRFV1QF5KFAF00TS0TE/e2e-repos python3 tests/test_e2e.py` (setup failed: `.venv` absent)</code>
- <code>`DATABASE_URL=postgresql://localhost/wikihub_test REPOS_DIR=/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXWD7SRFV1QF5KFAF00TS0TE/e2e-repos python3 tests/test_e2e.py` (setup failed: missing `sqlalchemy`)</code>
- `python3.11 -m venv /var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXWD7SRFV1QF5KFAF00TS0TE/venv && .../venv/bin/python -m pip install -r requirements.txt`
- <code>`DATABASE_URL=postgresql://localhost/wikihub_test REPOS_DIR=/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXWD7SRFV1QF5KFAF00TS0TE/e2e-repos .../venv/bin/python tests/test_e2e.py` (setup failed: shared Postgres.app permission gate)</code>
- `initdb -D /var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXWD7SRFV1QF5KFAF00TS0TE/pgdata --auth=trust --username=jacobcole --encoding=UTF8 && pg_ctl ... -p 7543 -h 127.0.0.1 start && createdb ... wikihub_test`
- `DATABASE_URL=postgresql://jacobcole@127.0.0.1:7543/wikihub_test REPOS_DIR=/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXWD7SRFV1QF5KFAF00TS0TE/e2e-repos .../venv/bin/python tests/test_e2e.py`
- `SECRET_KEY=dev DATABASE_URL=postgresql://jacobcole@127.0.0.1:7543/wikihub_test REPOS_DIR=/var/folders/04/j5yqtsfs3l527xrkvtxzy60h0000gn/T/no-mistakes-evidence/01KXWD7SRFV1QF5KFAF00TS0TE/browser-repos ADMIN_TOKEN=devtoken SESSION_COOKIE_SECURE=0 .../venv/bin/flask --app wsgi.py run --port 7544 --no-debugger`
- <code>`curl` API setup for `visualtester` account and two public wiki pages, followed by browser navigation to `http://127.0.0.1:7544/@visualtester/visualtester/wiki/index`</code>
- <code>`chrome-devtools-axi hover` on the `wiki/target` link and snapshot check showing `Target Page` preview plus `hide previews` action</code>
- <code>`/Users/jacobcole/.local/pipx/venvs/playwright/bin/python` browser script to capture screenshots, click `hide previews`, verify `localStorage.wh_hover_previews === &#34;off&#34;`, verify no card appears after re-hover, and verify closed menu computed `visibility: hidden` after transition</code>
- <code>`pg_ctl ... stop`, stopped the Flask process, removed transient venv/Postgres/repos/test credential files from the evidence directory, and confirmed `git status --short` was clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
